### PR TITLE
Add perf environment with JMeter + BlazeMeter load testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -934,6 +934,41 @@ pipeline {
             }
         }
 
+        /*
+         * =========================
+         * PERFORMANCE TEST (BlazeMeter / JMeter)
+         * =========================
+         * Runs against the `perf` environment only. Spinnaker is expected to
+         * deploy the new image to perf before this stage executes; here we
+         * simply drive the load test and gate on SLOs configured in
+         * performance/blazemeter.yml.
+         */
+        stage('Performance Test (BlazeMeter)') {
+            environment {
+                PERF_HOST = 'ems-perf.internal'
+                PERF_PORT = '8080'
+            }
+            steps {
+                withCredentials([
+                    string(credentialsId: 'blazemeter-api-key',    variable: 'BLAZEMETER_API_KEY'),
+                    string(credentialsId: 'blazemeter-api-secret', variable: 'BLAZEMETER_API_SECRET')
+                ]) {
+                    sh '''
+                        pip install --quiet bzt
+                        bzt performance/blazemeter.yml -cloud \
+                          -o settings.env.host=${PERF_HOST} \
+                          -o settings.env.port=${PERF_PORT}
+                    '''
+                }
+            }
+            post {
+                always {
+                    junit testResults: 'build/perf/junit.xml', allowEmptyResults: true
+                    archiveArtifacts artifacts: 'build/perf/**', allowEmptyArchive: true
+                }
+            }
+        }
+
     } // ✅ stages CLOSED HERE
 
     /*

--- a/README.md
+++ b/README.md
@@ -45,8 +45,13 @@ ECS cluster, IAM, RDS, ECR, secrets. Run once per environment, re-run when
 infra changes:
 ```bash
 ./scripts/deploy.sh dev
+./scripts/deploy.sh perf
 ./scripts/deploy.sh prod
 ```
+
+The `perf` environment mirrors prod (Redis + Kafka enabled) and is the target
+for load tests. See [`performance/README.md`](performance/README.md) for the
+JMeter plan and BlazeMeter wiring.
 
 **2. Application (Spinnaker).** Provisions ECS services and task definitions.
 Triggered automatically by every push to `develop` or `main` via Jenkins.

--- a/jules.yml
+++ b/jules.yml
@@ -54,6 +54,13 @@ test:
     reports: target/failsafe-reports/*.xml
     requires:
       - docker                       # Testcontainers needs the docker socket
+  performance:
+    enabled: true
+    tool: blazemeter                 # JMeter under the hood, executed via Taurus
+    plan: performance/jmeter/ems-load-test.jmx
+    config: performance/blazemeter.yml
+    runs-against: perf               # only against the perf environment
+    fail-on-slo-breach: true
 
 # ---------------------------------------------------------------------------
 # Security scans — run in parallel after tests pass
@@ -116,6 +123,20 @@ deploy:
       smoke-test:
         path: /actuator/health
         expected-status: 200
+    - name: perf
+      branches: [main]
+      auto-promote: true               # auto-deploy after dev to run load tests
+      smoke-test:
+        path: /actuator/health
+        expected-status: 200
+      perf-test:
+        tool: blazemeter
+        plan: performance/jmeter/ems-load-test.jmx
+        config: performance/blazemeter.yml
+        slo:
+          avg-response-ms: 500
+          p95-response-ms: 1500
+          error-rate-pct: 1
     - name: prod
       branches: [main]
       auto-promote: false              # manual judgment in Spinnaker

--- a/performance/README.md
+++ b/performance/README.md
@@ -1,0 +1,59 @@
+# EMS Performance Testing
+
+Load tests for the EMS service, runnable with **JMeter** locally and **BlazeMeter** in the cloud.
+Both consume the same `jmeter/ems-load-test.jmx` plan, so the test surface is identical.
+
+## Layout
+
+```
+performance/
+  jmeter/
+    ems-load-test.jmx     # JMeter test plan (parameterized)
+  blazemeter.yml          # Taurus / BlazeMeter wrapper
+  README.md
+```
+
+## Targeting the perf environment
+
+The Spring profile `perf` is defined in `src/main/resources/application-perf.yml`.
+Terraform variables for the env live in `terraform/variables/perf.tfvars`.
+
+The default target host is `ems-perf.internal:8080`. Override per-run.
+
+## Run locally with JMeter
+
+```sh
+mvn -Pperf-test verify \
+  -Dperf.host=ems-perf.internal \
+  -Dperf.port=8080 \
+  -Dperf.users=50 \
+  -Dperf.duration=300
+```
+
+Or directly with the JMeter CLI:
+
+```sh
+jmeter -n -t performance/jmeter/ems-load-test.jmx \
+       -Jhost=ems-perf.internal -Jport=8080 \
+       -Jusers=50 -JrampUp=30 -Jduration=300 \
+       -l build/perf/results.jtl -e -o build/perf/html
+```
+
+## Run in BlazeMeter cloud
+
+```sh
+pip install bzt
+export BLAZEMETER_API_KEY=...
+export BLAZEMETER_API_SECRET=...
+bzt performance/blazemeter.yml -cloud
+```
+
+## Pass/Fail SLOs
+
+Configured in `blazemeter.yml`:
+
+- avg response time < 500ms
+- p95 response time < 1500ms
+- error rate < 1%
+
+Breaching any SLO fails the run (and the CI stage).

--- a/performance/blazemeter.yml
+++ b/performance/blazemeter.yml
@@ -1,0 +1,65 @@
+# ---------------------------------------------------------------------------
+# BlazeMeter / Taurus configuration for the EMS perf environment.
+#
+# Run locally with Taurus:
+#     bzt performance/blazemeter.yml
+#
+# Run in BlazeMeter cloud:
+#     bzt performance/blazemeter.yml -cloud
+#
+# Override host/users from CLI:
+#     bzt performance/blazemeter.yml -o modules.jmeter.properties.host=ems-perf.internal \
+#                                    -o execution.0.concurrency=200
+#
+# CI/CD: the BlazeMeter API key is read from the BLAZEMETER_API_KEY /
+# BLAZEMETER_API_SECRET env vars (mapped from Jenkins credentials).
+# ---------------------------------------------------------------------------
+
+execution:
+  - executor: jmeter
+    scenario: ems-api
+    concurrency: 50
+    ramp-up: 30s
+    hold-for: 5m
+    throughput: 600          # requests/min cap across the thread group
+
+scenarios:
+  ems-api:
+    script: jmeter/ems-load-test.jmx
+
+settings:
+  env:
+    # Default target — override per-environment via -o or CLI -P props.
+    host: ems-perf.internal
+    port: 8080
+    protocol: http
+
+modules:
+  jmeter:
+    version: 5.6.3
+    properties:
+      host: ${host}
+      port: ${port}
+      protocol: ${protocol}
+
+  cloud:
+    # BlazeMeter project + test will be created/updated by name on first run.
+    project: EMS
+    test: EMS-Perf-Load
+    token: ${BLAZEMETER_API_KEY}:${BLAZEMETER_API_SECRET}
+
+reporting:
+  - module: console
+  - module: final-stats
+    summary: true
+    percentiles: true
+    test-duration: true
+    dump-xml: build/perf/stats.xml
+  - module: junit-xml
+    filename: build/perf/junit.xml
+  - module: passfail
+    criteria:
+      # Fail the build if perf SLOs are missed.
+      - avg-rt of ems-api>500ms for 30s, stop as failed
+      - p95.0 of ems-api>1500ms, stop as failed
+      - fail of ems-api>1% for 1m, stop as failed

--- a/performance/jmeter/ems-load-test.jmx
+++ b/performance/jmeter/ems-load-test.jmx
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.6.3">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="EMS Load Test" enabled="true">
+      <stringProp name="TestPlan.comments">Load test for EMS REST API. Run via JMeter CLI, BlazeMeter cloud, or Taurus.</stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments">
+          <elementProp name="BASE_HOST" elementType="Argument">
+            <stringProp name="Argument.name">BASE_HOST</stringProp>
+            <stringProp name="Argument.value">${__P(host,localhost)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="BASE_PORT" elementType="Argument">
+            <stringProp name="Argument.name">BASE_PORT</stringProp>
+            <stringProp name="Argument.value">${__P(port,8080)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="BASE_PROTOCOL" elementType="Argument">
+            <stringProp name="Argument.name">BASE_PROTOCOL</stringProp>
+            <stringProp name="Argument.value">${__P(protocol,http)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="USERS" elementType="Argument">
+            <stringProp name="Argument.name">USERS</stringProp>
+            <stringProp name="Argument.value">${__P(users,50)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="RAMP_UP" elementType="Argument">
+            <stringProp name="Argument.name">RAMP_UP</stringProp>
+            <stringProp name="Argument.value">${__P(rampUp,30)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+          <elementProp name="DURATION" elementType="Argument">
+            <stringProp name="Argument.name">DURATION</stringProp>
+            <stringProp name="Argument.value">${__P(duration,300)}</stringProp>
+            <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
+        </collectionProp>
+      </elementProp>
+    </TestPlan>
+    <hashTree>
+      <ConfigTestElement guiclass="HttpDefaultsGui" testclass="ConfigTestElement" testname="HTTP Request Defaults" enabled="true">
+        <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+          <collectionProp name="Arguments.arguments"/>
+        </elementProp>
+        <stringProp name="HTTPSampler.domain">${BASE_HOST}</stringProp>
+        <stringProp name="HTTPSampler.port">${BASE_PORT}</stringProp>
+        <stringProp name="HTTPSampler.protocol">${BASE_PROTOCOL}</stringProp>
+        <stringProp name="HTTPSampler.connect_timeout">5000</stringProp>
+        <stringProp name="HTTPSampler.response_timeout">10000</stringProp>
+      </ConfigTestElement>
+      <hashTree/>
+      <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+        <collectionProp name="HeaderManager.headers">
+          <elementProp name="Content-Type" elementType="Header">
+            <stringProp name="Header.name">Content-Type</stringProp>
+            <stringProp name="Header.value">application/json</stringProp>
+          </elementProp>
+          <elementProp name="Accept" elementType="Header">
+            <stringProp name="Header.name">Accept</stringProp>
+            <stringProp name="Header.value">application/json</stringProp>
+          </elementProp>
+        </collectionProp>
+      </HeaderManager>
+      <hashTree/>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="EMS API Users" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">-1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${USERS}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${RAMP_UP}</stringProp>
+        <boolProp name="ThreadGroup.scheduler">true</boolProp>
+        <stringProp name="ThreadGroup.duration">${DURATION}</stringProp>
+        <stringProp name="ThreadGroup.delay">0</stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">false</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GET /actuator/health" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.path">/actuator/health</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+        </HTTPSamplerProxy>
+        <hashTree>
+          <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Status 200" enabled="true">
+            <collectionProp name="Asserion.test_strings">
+              <stringProp name="49586">200</stringProp>
+            </collectionProp>
+            <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+            <boolProp name="Assertion.assume_success">false</boolProp>
+            <intProp name="Assertion.test_type">8</intProp>
+          </ResponseAssertion>
+          <hashTree/>
+        </hashTree>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GET /api/v1/departments" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.path">/api/v1/departments</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GET /api/v1/employees" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.path">/api/v1/employees</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="GET /api/v1/projects" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.path">/api/v1/projects</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <ConstantThroughputTimer guiclass="TestBeanGUI" testclass="ConstantThroughputTimer" testname="Throttle" enabled="true">
+          <intProp name="calcMode">2</intProp>
+          <doubleProp>
+            <name>throughput</name>
+            <value>600.0</value>
+            <savedValue>0.0</savedValue>
+          </doubleProp>
+        </ConstantThroughputTimer>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,14 @@
 
 		<tomcat.version>10.1.53</tomcat.version>
 		<spring-security.version>6.5.9</spring-security.version>
+
+		<jmeter-maven-plugin.version>3.8.0</jmeter-maven-plugin.version>
+		<perf.host>localhost</perf.host>
+		<perf.port>8080</perf.port>
+		<perf.protocol>http</perf.protocol>
+		<perf.users>50</perf.users>
+		<perf.rampUp>30</perf.rampUp>
+		<perf.duration>300</perf.duration>
 	</properties>
 
 	<dependencyManagement>
@@ -344,5 +352,56 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<!-- ==========================================================
+	     Performance test profile.
+	     Activated with: mvn -Pperf-test verify
+	     Runs the JMeter plan in performance/jmeter against the
+	     host configured via -Dperf.host (default: localhost).
+	     ========================================================== -->
+	<profiles>
+		<profile>
+			<id>perf-test</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.lazerycode.jmeter</groupId>
+						<artifactId>jmeter-maven-plugin</artifactId>
+						<version>${jmeter-maven-plugin.version}</version>
+						<configuration>
+							<testFilesDirectory>${project.basedir}/performance/jmeter</testFilesDirectory>
+							<resultsDirectory>${project.build.directory}/jmeter/results</resultsDirectory>
+							<generateReports>true</generateReports>
+							<ignoreResultFailures>false</ignoreResultFailures>
+							<propertiesUser>
+								<host>${perf.host}</host>
+								<port>${perf.port}</port>
+								<protocol>${perf.protocol}</protocol>
+								<users>${perf.users}</users>
+								<rampUp>${perf.rampUp}</rampUp>
+								<duration>${perf.duration}</duration>
+							</propertiesUser>
+						</configuration>
+						<executions>
+							<execution>
+								<id>jmeter-tests</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>jmeter</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>jmeter-check-results</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>results</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -20,8 +20,8 @@ ENV="${1:?usage: $0 <env> [destroy]}"
 ARG2="${2:-}"
 
 case "$ENV" in
-  dev|prod) ;;
-  *) echo "env must be one of: dev, prod" >&2; exit 1 ;;
+  dev|perf|prod) ;;
+  *) echo "env must be one of: dev, perf, prod" >&2; exit 1 ;;
 esac
 
 VAR_FILE="variables/${ENV}.tfvars"

--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# perf-test.sh — run the EMS load test against the perf environment.
+#
+# Modes:
+#   local     : run JMeter locally via the Maven `perf-test` profile
+#   blazemeter: run via Taurus/BlazeMeter cloud (requires bzt + API creds)
+#
+# Usage:
+#   scripts/perf-test.sh local      [host] [port] [users] [duration]
+#   scripts/perf-test.sh blazemeter [host] [port]
+#
+# Defaults target the perf environment internal hostname.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+MODE="${1:-local}"
+HOST="${2:-ems-perf.internal}"
+PORT="${3:-8080}"
+USERS="${4:-50}"
+DURATION="${5:-300}"
+
+case "$MODE" in
+  local)
+    exec ./mvnw -B -ntp -Pperf-test verify \
+      -DskipTests \
+      -Dperf.host="$HOST" \
+      -Dperf.port="$PORT" \
+      -Dperf.users="$USERS" \
+      -Dperf.duration="$DURATION"
+    ;;
+
+  blazemeter)
+    : "${BLAZEMETER_API_KEY:?BLAZEMETER_API_KEY must be set}"
+    : "${BLAZEMETER_API_SECRET:?BLAZEMETER_API_SECRET must be set}"
+    exec bzt performance/blazemeter.yml -cloud \
+      -o settings.env.host="$HOST" \
+      -o settings.env.port="$PORT"
+    ;;
+
+  *)
+    echo "Unknown mode: $MODE" >&2
+    echo "Usage: $0 {local|blazemeter} [host] [port] [users] [duration]" >&2
+    exit 2
+    ;;
+esac

--- a/src/main/resources/application-perf.yml
+++ b/src/main/resources/application-perf.yml
@@ -1,0 +1,70 @@
+###############################################################################
+# PERF profile - dedicated performance/load testing environment.
+# Sized between dev and prod: full Redis + Kafka wired so behavior matches prod,
+# but logging and trace sampling tuned for high-volume runs (JMeter / BlazeMeter).
+###############################################################################
+
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME:ems}?useSSL=true&serverTimezone=UTC
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 100
+      minimum-idle: 20
+      connection-timeout: 20000
+      idle-timeout: 300000
+      max-lifetime: 1800000
+      leak-detection-threshold: 60000
+      validation-timeout: 5000
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
+      ssl:
+        enabled: true
+      timeout: 2s
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    properties:
+      security.protocol: SASL_SSL
+      sasl.mechanism: AWS_MSK_IAM
+      sasl.jaas.config: software.amazon.msk.auth.iam.IAMLoginModule required;
+      sasl.client.callback.handler.class: software.amazon.msk.auth.iam.IAMClientCallbackHandler
+
+  session:
+    store-type: redis
+    timeout: 30m
+
+ems:
+  kafka:
+    enabled: true
+    topics:
+      replication-factor: 3
+      min-insync-replicas: 2
+    consumer:
+      group-id: ems-department-consumer-perf
+
+# Lower trace sampling under load — high sampling at high RPS overwhelms the
+# collector and skews latency numbers for the run itself.
+management:
+  tracing:
+    sampling:
+      probability: 0.05
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      percentiles:
+        http.server.requests: 0.5, 0.9, 0.95, 0.99
+
+logging:
+  level:
+    root: WARN
+    com.ems.ems: INFO
+    org.springframework: WARN
+    org.hibernate: WARN

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,12 +16,12 @@ variable "aws_region" {
 }
 
 variable "env" {
-  description = "Environment name (dev, prod)."
+  description = "Environment name (dev, perf, prod)."
   type        = string
 
   validation {
-    condition     = contains(["dev", "prod"], var.env)
-    error_message = "env must be one of: dev, prod."
+    condition     = contains(["dev", "perf", "prod"], var.env)
+    error_message = "env must be one of: dev, perf, prod."
   }
 }
 

--- a/terraform/variables/perf.tfvars
+++ b/terraform/variables/perf.tfvars
@@ -1,0 +1,7 @@
+env = "perf"
+
+db_name              = "ems"
+db_username          = "ems_admin"
+db_instance_class    = "db.t4g.medium"
+db_allocated_storage = 50
+create_read_replica  = false


### PR DESCRIPTION
- New Spring profile application-perf.yml (Redis + Kafka enabled, prod-like)
- JMeter plan in performance/jmeter/ems-load-test.jmx covering health and core API endpoints
- Taurus/BlazeMeter wrapper performance/blazemeter.yml with SLO pass/fail
- Maven perf-test profile invoking jmeter-maven-plugin
- scripts/perf-test.sh for local + cloud runs
- Jenkinsfile stage for BlazeMeter cloud execution against perf
- jules.yml: perf environment + performance test gate
- Terraform: env validation accepts perf, variables/perf.tfvars added
- deploy.sh + README updated to include perf