### PR TITLE
Add perf environment + JMeter/BlazeMeter pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -935,39 +935,11 @@ pipeline {
         }
 
         /*
-         * =========================
-         * PERFORMANCE TEST (BlazeMeter / JMeter)
-         * =========================
-         * Runs against the `perf` environment only. Spinnaker is expected to
-         * deploy the new image to perf before this stage executes; here we
-         * simply drive the load test and gate on SLOs configured in
-         * performance/blazemeter.yml.
+         * NOTE: The BlazeMeter performance test stage has moved out of this
+         * pipeline. Spinnaker now drives the perf flow:
+         *   Deploy Perf -> Smoke Perf -> trigger Jenkins job 'ems-perf-load-test'
+         * That job is defined by Jenkinsfile.perf in this repo.
          */
-        stage('Performance Test (BlazeMeter)') {
-            environment {
-                PERF_HOST = 'ems-perf.internal'
-                PERF_PORT = '8080'
-            }
-            steps {
-                withCredentials([
-                    string(credentialsId: 'blazemeter-api-key',    variable: 'BLAZEMETER_API_KEY'),
-                    string(credentialsId: 'blazemeter-api-secret', variable: 'BLAZEMETER_API_SECRET')
-                ]) {
-                    sh '''
-                        pip install --quiet bzt
-                        bzt performance/blazemeter.yml -cloud \
-                          -o settings.env.host=${PERF_HOST} \
-                          -o settings.env.port=${PERF_PORT}
-                    '''
-                }
-            }
-            post {
-                always {
-                    junit testResults: 'build/perf/junit.xml', allowEmptyResults: true
-                    archiveArtifacts artifacts: 'build/perf/**', allowEmptyArchive: true
-                }
-            }
-        }
 
     } // ✅ stages CLOSED HERE
 

--- a/Jenkinsfile.perf
+++ b/Jenkinsfile.perf
@@ -1,0 +1,70 @@
+/*
+ * Jenkinsfile.perf — downstream Jenkins job 'ems-perf-load-test'.
+ *
+ * Triggered by Spinnaker's `BlazeMeter Load Test (Perf)` stage AFTER perf is
+ * deployed and smoke-tested. This pipeline does ONE thing: run the BlazeMeter
+ * cloud load test against the perf cluster and gate on the SLOs declared in
+ * performance/blazemeter.yml.
+ *
+ * Build parameters (passed in by Spinnaker):
+ *   imageTag  — image just deployed to perf (recorded in build display name)
+ *   perfHost  — DNS name of the perf ALB (e.g. ems-perf.example.internal)
+ *   perfPort  — port on the perf ALB (e.g. 443)
+ */
+
+pipeline {
+
+    agent any
+
+    options {
+        timestamps()
+        ansiColor('xterm')
+        timeout(time: 30, unit: 'MINUTES')
+        disableConcurrentBuilds()
+    }
+
+    parameters {
+        string(name: 'imageTag', defaultValue: 'unknown',                    description: 'Image tag now running on perf')
+        string(name: 'perfHost', defaultValue: 'ems-perf.example.internal',  description: 'Perf ALB hostname')
+        string(name: 'perfPort', defaultValue: '443',                        description: 'Perf ALB port')
+    }
+
+    stages {
+
+        stage('Init') {
+            steps {
+                script {
+                    currentBuild.displayName = "#${env.BUILD_NUMBER} ${params.imageTag}"
+                }
+                sh 'pip install --quiet bzt'
+            }
+        }
+
+        stage('BlazeMeter Cloud Run') {
+            steps {
+                withCredentials([
+                    string(credentialsId: 'blazemeter-api-key',    variable: 'BLAZEMETER_API_KEY'),
+                    string(credentialsId: 'blazemeter-api-secret', variable: 'BLAZEMETER_API_SECRET')
+                ]) {
+                    sh '''
+                        bzt performance/blazemeter.yml -cloud \
+                          -o settings.env.host=${perfHost} \
+                          -o settings.env.port=${perfPort}
+                    '''
+                }
+            }
+            post {
+                always {
+                    junit testResults: 'build/perf/junit.xml', allowEmptyResults: true
+                    archiveArtifacts artifacts: 'build/perf/**', allowEmptyArchive: true
+                }
+            }
+        }
+    }
+
+    post {
+        success { echo "✓ Perf SLOs passed for ${params.imageTag}" }
+        failure { echo "✗ Perf SLOs FAILED for ${params.imageTag} — prod promotion blocked" }
+        always  { cleanWs() }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,16 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- ArchUnit — enforces architectural rules in unit tests.
+		     Used by ArchitectureRulesTest to block synchronous HTTP/Kafka
+		     clients from being injected into transactional services. -->
+		<dependency>
+			<groupId>com.tngtech.archunit</groupId>
+			<artifactId>archunit-junit5</artifactId>
+			<version>1.3.0</version>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>

--- a/spinnaker/pipelines/ems-deploy-cicd.json
+++ b/spinnaker/pipelines/ems-deploy-cicd.json
@@ -9,6 +9,8 @@
     "",
     "Flow:",
     "  Webhook -> Deploy Dev (redblack) -> Smoke Dev",
+    "         -> Deploy Perf (redblack) -> Smoke Perf",
+    "         -> Run BlazeMeter Load Test (Jenkins job 'ems-perf-load-test')",
     "         -> [Manual Judgment if branch=main]",
     "         -> Deploy Prod Canary (1 task, canary target group)",
     "         -> Bake 10 min",
@@ -143,8 +145,130 @@
     },
 
     {
-      "refId": "3",
+      "refId": "perf-deploy",
       "requisiteStageRefIds": ["2"],
+      "name": "Deploy to Perf",
+      "type": "createServerGroup",
+      "stageEnabled": {
+        "type": "expression",
+        "expression": "${parameters.branch == 'main'}"
+      },
+      "cloudProvider": "ecs",
+      "credentials": "aws-perf",
+      "region": "us-east-1",
+      "application": "ems",
+      "stack": "perf",
+      "ecsClusterName": "image-uploader-perf",
+      "launchType": "FARGATE",
+      "platformVersion": "LATEST",
+      "computeUnits": 1024,
+      "reservedMemory": 2048,
+      "containerInformation": {
+        "imageDescription": {
+          "imageId":    "${parameters.ecrRegistry}/${parameters.ecrRepo}:${parameters.imageTag}",
+          "registry":   "${parameters.ecrRegistry}",
+          "repository": "${parameters.ecrRepo}",
+          "tag":        "${parameters.imageTag}"
+        }
+      },
+      "containerPort": 8080,
+      "targetGroupMappings": [
+        {
+          "containerName": "ems",
+          "containerPort": 8080,
+          "targetGroup":   "image-uploader-perf-stable"
+        }
+      ],
+      "networkMode": "awsvpc",
+      "subnetType":  "ecs-tasks-perf",
+      "securityGroups": ["image-uploader-perf-tasks"],
+      "associatePublicIpAddress": false,
+      "iamRole":     "image-uploader-perf-task-exec",
+      "taskRoleArn": "image-uploader-perf-task",
+      "containerDefinitions": [
+        {
+          "name":      "ems",
+          "image":     "${parameters.ecrRegistry}/${parameters.ecrRepo}:${parameters.imageTag}",
+          "essential": true,
+          "portMappings": [{ "containerPort": 8080, "protocol": "tcp" }],
+          "environment": [
+            { "name": "SPRING_PROFILES_ACTIVE", "value": "perf" },
+            { "name": "APP_ID",                 "value": "${parameters.appId}" }
+          ],
+          "secrets": [
+            { "name": "DB_HOST",                  "valueFrom": "/perf/image-uploader/DB_HOST" },
+            { "name": "DB_PORT",                  "valueFrom": "/perf/image-uploader/DB_PORT" },
+            { "name": "DB_NAME",                  "valueFrom": "/perf/image-uploader/DB_NAME" },
+            { "name": "DB_USERNAME",              "valueFrom": "/perf/image-uploader/DB_USERNAME" },
+            { "name": "DB_PASSWORD",              "valueFrom": "/perf/image-uploader/DB_PASSWORD" },
+            { "name": "REDIS_HOST",               "valueFrom": "/perf/image-uploader/REDIS_HOST" },
+            { "name": "REDIS_PORT",               "valueFrom": "/perf/image-uploader/REDIS_PORT" },
+            { "name": "REDIS_PASSWORD",           "valueFrom": "/perf/image-uploader/REDIS_PASSWORD" },
+            { "name": "KAFKA_BOOTSTRAP_SERVERS",  "valueFrom": "/perf/image-uploader/KAFKA_BOOTSTRAP_SERVERS" }
+          ],
+          "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+              "awslogs-group":         "/ecs/image-uploader-perf",
+              "awslogs-region":        "us-east-1",
+              "awslogs-stream-prefix": "ecs"
+            }
+          }
+        }
+      ],
+      "capacity":         { "min": 2, "max": 4, "desired": 2 },
+      "strategy":         "redblack",
+      "maxRemainingAsgs": 2,
+      "rollback":         { "onFailure": true },
+      "scaleDown":        true
+    },
+
+    {
+      "refId": "perf-smoke",
+      "requisiteStageRefIds": ["perf-deploy"],
+      "name": "Smoke Test Perf",
+      "type": "webhook",
+      "stageEnabled": {
+        "type": "expression",
+        "expression": "${parameters.branch == 'main'}"
+      },
+      "method": "GET",
+      "url": "https://ems-perf.example.internal/actuator/health",
+      "waitForCompletion": true,
+      "successStatuses": "200"
+    },
+
+    {
+      "_comment": [
+        "Triggers a downstream Jenkins job 'ems-perf-load-test' that runs",
+        "BlazeMeter cloud against the freshly deployed perf cluster.",
+        "Spinnaker waits for the Jenkins job to finish and inherits its result.",
+        "The Jenkins job uses Jenkinsfile.perf (PERF_ONLY=true) and gates on",
+        "the SLOs defined in performance/blazemeter.yml."
+      ],
+      "refId": "perf-loadtest",
+      "requisiteStageRefIds": ["perf-smoke"],
+      "name": "BlazeMeter Load Test (Perf)",
+      "type": "jenkins",
+      "stageEnabled": {
+        "type": "expression",
+        "expression": "${parameters.branch == 'main'}"
+      },
+      "master":  "ems-jenkins",
+      "job":     "ems-perf-load-test",
+      "parameters": {
+        "imageTag":  "${parameters.imageTag}",
+        "perfHost":  "ems-perf.example.internal",
+        "perfPort":  "443"
+      },
+      "waitForCompletion":     true,
+      "markUnstableAsSuccessful": false,
+      "failPipeline":          true
+    },
+
+    {
+      "refId": "3",
+      "requisiteStageRefIds": ["perf-loadtest"],
       "name": "Manual Judgment (Prod Approval)",
       "type": "manualJudgment",
       "stageEnabled": {
@@ -155,7 +279,7 @@
         { "value": "Promote to prod" },
         { "value": "Hold" }
       ],
-      "instructions": "Review dev smoke test results and approve prod deploy.\n\nJenkins build: ${parameters.buildUrl}\nImage tag: ${parameters.imageTag}",
+      "instructions": "Review dev smoke + perf BlazeMeter SLO results, then approve prod deploy.\n\nJenkins build: ${parameters.buildUrl}\nImage tag: ${parameters.imageTag}",
       "notifications": [
         {
           "address": "#ems-releases",

--- a/src/test/java/com/ems/ems/architecture/ArchitectureRulesTest.java
+++ b/src/test/java/com/ems/ems/architecture/ArchitectureRulesTest.java
@@ -1,0 +1,56 @@
+package com.ems.ems.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Pre-perf gate: catches the most common causes of perf regressions before
+ * the BlazeMeter run. These are architectural — slow code patterns shouldn't
+ * even compile-pass into the perf environment.
+ */
+class ArchitectureRulesTest {
+
+    private static final JavaClasses APP_CLASSES = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("com.ems.ems");
+
+    /**
+     * Synchronous HTTP / Kafka calls inside service implementations risk
+     * holding a DB transaction open across a network round-trip — the classic
+     * cause of pool exhaustion under load. The Kafka producer wrapper is the
+     * only sanctioned async sender; service code should depend on that, not
+     * on KafkaTemplate / RestTemplate / WebClient / HttpClient directly.
+     */
+    @Test
+    void services_should_not_depend_on_synchronous_remote_clients() {
+        noClasses()
+                .that().resideInAPackage("..serviceImpl..")
+                .should().dependOnClassesThat()
+                .haveFullyQualifiedName("org.springframework.web.client.RestTemplate")
+                .orShould().dependOnClassesThat()
+                .haveFullyQualifiedName("org.springframework.web.reactive.function.client.WebClient")
+                .orShould().dependOnClassesThat()
+                .haveFullyQualifiedName("java.net.http.HttpClient")
+                .orShould().dependOnClassesThat()
+                .haveFullyQualifiedName("org.springframework.kafka.core.KafkaTemplate")
+                .because("synchronous remote calls inside @Transactional services exhaust the DB pool under load")
+                .check(APP_CLASSES);
+    }
+
+    /**
+     * Controllers shouldn't talk to repositories directly — keeps the
+     * transactional boundary at the service layer where it belongs.
+     */
+    @Test
+    void controllers_should_not_access_repositories_directly() {
+        noClasses()
+                .that().resideInAPackage("..controllers..")
+                .should().dependOnClassesThat().resideInAPackage("..repositories..")
+                .because("controllers must go through the service layer for the transactional boundary")
+                .check(APP_CLASSES);
+    }
+}

--- a/src/test/java/com/ems/ems/integration/DepartmentIT.java
+++ b/src/test/java/com/ems/ems/integration/DepartmentIT.java
@@ -28,6 +28,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import com.ems.ems.dtos.DepartmentDto;
 import com.ems.ems.repositories.DepartmentRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
 import org.testcontainers.containers.MariaDBContainer;
 /**
  * Integration test - boots the full Spring context against a real MySQL container.
@@ -70,6 +73,9 @@ class DepartmentIT {
 
     @Autowired
     private DepartmentRepository departmentRepository;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -163,5 +169,39 @@ class DepartmentIT {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.length()").value(
                         org.hamcrest.Matchers.greaterThanOrEqualTo(2)));
+    }
+
+    /**
+     * Pre-perf gate: catches N+1 regressions before they hit BlazeMeter.
+     * Listing departments must be a constant number of SQL statements,
+     * regardless of row count. The threshold is intentionally loose (5) so
+     * minor query plan changes don't break the build, but tight enough that
+     * an accidental N+1 over even a handful of rows trips it.
+     */
+    @Test
+    @DisplayName("GET /departments emits a bounded number of queries (no N+1)")
+    void listDoesNotIssueNPlusOneQueries() throws Exception {
+        for (int i = 0; i < 5; i++) {
+            DepartmentDto dto = DepartmentDto.builder()
+                    .name("perf-dept-" + i)
+                    .description("seed")
+                    .build();
+            mockMvc.perform(post("/api/v1/departments")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(dto)))
+                    .andExpect(status().isCreated());
+        }
+
+        Statistics stats = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        mockMvc.perform(get("/api/v1/departments"))
+                .andExpect(status().isOk());
+
+        long queries = stats.getPrepareStatementCount();
+        assertThat(queries)
+                .as("listing departments must not scale with row count — N+1 regression?")
+                .isLessThanOrEqualTo(5);
     }
 }

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -55,6 +55,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        # Enables Hibernate's per-session Statistics so query-count
+        # assertions in IT tests can detect N+1 regressions.
+        generate_statistics: true
 
   flyway:
     enabled: true


### PR DESCRIPTION
## Summary
- New `perf` Spring profile + Terraform tfvars + deploy.sh wiring (env between dev and prod, prod-shaped infra).
- JMeter test plan (`src/test/jmeter/`-style placement under `performance/jmeter/ems-load-test.jmx`) and a Taurus/BlazeMeter wrapper (`performance/blazemeter.yml`) with SLO pass/fail (avg < 500ms, p95 < 1500ms, errors < 1%).
- Spinnaker pipeline now runs `Deploy Perf → Smoke Perf → Jenkins job ems-perf-load-test (BlazeMeter cloud)` before the prod manual judgment. The new `Jenkinsfile.perf` defines that downstream job.
- Pre-perf gates to catch the most common load regressions cheaply:
  - ArchUnit rule blocking `RestTemplate`/`WebClient`/`HttpClient`/`KafkaTemplate` from `serviceImpl` (sync remote calls under `@Transactional` exhaust the pool under load).
  - Hibernate Statistics-based query-count assertion in `DepartmentIT` to catch N+1 regressions.

## Test plan
- [ ] `mvn verify` passes (new ArchUnit + IT assertions green)
- [ ] Spinnaker pipeline JSON imports cleanly (`spin pipeline save`)
- [ ] `bzt performance/blazemeter.yml` runs locally against a perf-shaped target
- [ ] Jenkins `ems-perf-load-test` job points at `Jenkinsfile.perf` and has `blazemeter-api-key` / `blazemeter-api-secret` credentials

https://claude.ai/code/session_017nU9w3ku1WLfzBBFKdC1hV

---
_Generated by [Claude Code](https://claude.ai/code/session_017nU9w3ku1WLfzBBFKdC1hV)_