### PR TITLE
Add GitHub Actions push-to-main auto-deploy + Windows runbook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,87 @@
+# Push to main  ->  build image (Jib -> ECR)  ->  trigger Spinnaker  ->  ECS Fargate.
+#
+# No AWS keys are stored in GitHub: the job mints a short-lived credential by
+# assuming the `github-actions-ems` role via OIDC (see terraform/spinnaker/
+# github_oidc.tf). Spinnaker performs the actual ECS deploy after the webhook.
+#
+# Required GitHub config (Settings -> Secrets and variables -> Actions):
+#   Variables:
+#     AWS_ROLE_ARN          terraform output github_actions_role_arn
+#     AWS_REGION            us-east-1
+#     SPINNAKER_GATE_URL    http://<spin-gate-loadbalancer-host>   (no trailing slash)
+#   Secrets:
+#     SPINNAKER_WEBHOOK_TOKEN   any shared string; must match echo.webhooks.defaultSecret
+
+name: deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:        # lets you trigger a deploy by hand from the Actions tab
+
+permissions:
+  id-token: write           # required for OIDC role assumption
+  contents: read
+
+concurrency:                # one deploy at a time; newer push cancels an in-flight one
+  group: deploy-main
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0     # git-commit-id plugin needs history for the image label
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Log in to Amazon ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Run tests
+        run: ./mvnw -B -ntp test
+
+      - name: Build and push image with Jib
+        run: >-
+          ./mvnw -B -ntp compile jib:build
+          -Djib.to.image=${{ steps.ecr.outputs.registry }}/ems:${{ github.sha }}
+          -Djib.to.tags=latest
+
+      - name: Trigger Spinnaker pipeline
+        run: |
+          curl -fsS -X POST "${{ vars.SPINNAKER_GATE_URL }}/webhooks/webhook/ems-build-complete" \
+            -H "X-Spinnaker-Token: ${{ secrets.SPINNAKER_WEBHOOK_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "$(cat <<JSON
+          {
+            "parameters": {
+              "imageTag":    "${{ github.sha }}",
+              "branch":      "main",
+              "ecrRegistry": "${{ steps.ecr.outputs.registry }}",
+              "ecrRepo":     "ems",
+              "buildUrl":    "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+          }
+          JSON
+          )"
+
+      - name: Summary
+        run: |
+          echo "### Deployed image" >> $GITHUB_STEP_SUMMARY
+          echo "\`${{ steps.ecr.outputs.registry }}/ems:${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Spinnaker pipeline **ems-deploy-cicd** triggered." >> $GITHUB_STEP_SUMMARY

--- a/CICD.md
+++ b/CICD.md
@@ -2,6 +2,17 @@
 
 End-to-end picture of how a commit becomes a running task on ECS Fargate.
 
+> **Active CI trigger: GitHub Actions.** This repo deploys via
+> `.github/workflows/deploy.yml` — push to `main` → Actions builds + pushes the
+> image (Jib → ECR via OIDC) → POSTs the webhook → Spinnaker deploys to ECS
+> Fargate. For the full step-by-step setup (Windows) see
+> [`DEPLOY-WINDOWS.md`](DEPLOY-WINDOWS.md).
+>
+> The **Jenkins** path documented below is the original, still-supported
+> alternative (`Jenkinsfile`). Everything from "Spinnaker (CD)" onward is
+> identical regardless of which CI tool triggers it — only the box that builds
+> the image and fires the webhook changes. Pick one; don't run both.
+
 ## Tools and what each one does
 
 | Tool        | Role                                                       |

--- a/DEPLOY-WINDOWS.md
+++ b/DEPLOY-WINDOWS.md
@@ -1,0 +1,356 @@
+# End-to-end deployment runbook (Windows)
+
+Stand up the infra, install Spinnaker, then get the **push-to-main → auto-deploy**
+loop working. Every command is PowerShell. Run them from a regular PowerShell
+window (not cmd). Copy blocks one at a time and read the comments.
+
+```
+git push origin main
+   │
+   ▼
+GitHub Actions   build + test, Jib pushes image to ECR (auth via OIDC, no keys)
+   │  POST webhook
+   ▼
+Spinnaker (on EKS)   createServerGroup (red/black)
+   ▼
+ECS Fargate   new task revision goes live behind the ALB
+```
+
+**Ownership:** Terraform owns the immutable platform (EKS for Spinnaker, plus
+the EMS ALB / ECS cluster / RDS / ECR / IAM / secrets). Spinnaker owns the ECS
+**services and task definitions** — it creates them on the first pipeline run.
+
+> **Cost warning.** This runs an EKS cluster (2× t3.large), an RDS instance, an
+> ALB, and 2 network load balancers. Ballpark **$10–15/day** left running. Tear
+> down with the Phase 9 steps when you're done for the day.
+
+---
+
+## Phase 0 — Install the tools (one time)
+
+Use [winget](https://learn.microsoft.com/windows/package-manager/) (built into
+Windows 10/11):
+
+```powershell
+winget install --id Hashicorp.Terraform -e
+winget install --id Amazon.AWSCLI -e
+winget install --id Kubernetes.kubectl -e
+winget install --id Helm.Helm -e
+winget install --id Git.Git -e
+winget install --id Eclipse.Temurin.21.JDK -e   # only needed if you build locally
+```
+
+Close and reopen PowerShell so the new tools are on `PATH`, then verify:
+
+```powershell
+terraform version
+aws --version
+kubectl version --client
+git --version
+```
+
+Configure AWS credentials (an IAM user/SSO profile with admin-ish rights for
+the initial bootstrap):
+
+```powershell
+aws configure
+aws sts get-caller-identity      # confirm account + identity
+```
+
+Get your account ID into a variable you'll reuse this session:
+
+```powershell
+$ACCOUNT = (aws sts get-caller-identity --query Account --output text)
+$REGION  = "us-east-1"
+echo $ACCOUNT
+```
+
+Clone the repo if you haven't:
+
+```powershell
+git clone https://github.com/sarkr72/practice.git
+cd practice
+```
+
+---
+
+## Phase 1 — Bootstrap the Terraform backend (one time, manual)
+
+Terraform stores its state in S3 with a DynamoDB lock table. These must exist
+**before** `terraform init`, so you create them by hand once. Names are already
+wired into `terraform/ems/providers.tf` and `terraform/spinnaker/providers.tf`.
+
+```powershell
+aws s3api create-bucket --bucket rinku-tfstate-001 --region us-east-1
+
+aws s3api put-bucket-versioning --bucket rinku-tfstate-001 `
+  --versioning-configuration Status=Enabled
+
+aws s3api put-public-access-block --bucket rinku-tfstate-001 `
+  --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+
+aws dynamodb create-table --table-name terraform-locks `
+  --attribute-definitions AttributeName=LockID,AttributeType=S `
+  --key-schema AttributeName=LockID,KeyType=HASH `
+  --billing-mode PAY_PER_REQUEST --region us-east-1
+```
+
+> The bucket name is globally unique. If `rinku-tfstate-001` is taken, pick your
+> own and change the `bucket =` line in both `providers.tf` files plus
+> `persistence_bucket_name` in `terraform/spinnaker/variables.tf`.
+
+---
+
+## Phase 2 — Provision the Spinnaker control plane (EKS + S3 + IAM + GitHub OIDC)
+
+```powershell
+cd terraform\spinnaker
+
+# Account ID for this root (gitignored — never committed)
+"aws_account_id = `"$ACCOUNT`"" | Out-File -Encoding ascii account.auto.tfvars
+
+terraform init
+terraform apply        # review the plan, type: yes
+```
+
+This creates: the EKS cluster, its OIDC provider, the IRSA role Spinnaker
+assumes, the S3 persistence bucket, **and** the GitHub Actions OIDC role
+(`github_oidc.tf`). Takes ~15–20 min for EKS.
+
+Capture the outputs you'll need later:
+
+```powershell
+$ROLE_ARN   = (terraform output -raw github_actions_role_arn)   # for GitHub
+$SPIN_ROLE  = (terraform output -raw spinnaker_role_arn)
+$BUCKET     = (terraform output -raw persistence_bucket)
+echo "GitHub role:    $ROLE_ARN"
+echo "Spinnaker role: $SPIN_ROLE"
+echo "Bucket:         $BUCKET"
+```
+
+Point kubectl at the new cluster:
+
+```powershell
+aws eks update-kubeconfig --name spinnaker --region us-east-1
+kubectl get nodes        # should list 2 Ready nodes
+```
+
+---
+
+## Phase 3 — Install Spinnaker on the cluster
+
+### 3a. Install the Spinnaker Operator
+
+```powershell
+# from terraform\spinnaker
+kubectl apply -f manifests\operator\
+kubectl -n spinnaker-operator rollout status deploy/spinnaker-operator
+```
+
+(If `manifests\operator\` only contains the namespace + a README, follow the
+upstream operator install in `manifests\operator\README.md` — it's a single
+`kubectl apply -k` against the published operator kustomize bundle.)
+
+### 3b. Render the SpinnakerService manifest (PowerShell — no envsubst needed)
+
+```powershell
+cd manifests\spinnaker
+
+# Read the template and substitute the placeholders
+$svc = Get-Content spinnakerservice.yaml -Raw
+$svc = $svc.Replace('__AWS_ACCOUNT_ID__',     $ACCOUNT)
+$svc = $svc.Replace('__AWS_REGION__',          $REGION)
+$svc = $svc.Replace('__SPINNAKER_ROLE_ARN__',  $SPIN_ROLE)
+$svc = $svc.Replace('__PERSISTENCE_BUCKET__',  $BUCKET)
+$svc | Out-File -Encoding ascii spinnakerservice.rendered.yaml
+
+kubectl apply -f spinnakerservice.rendered.yaml
+```
+
+### 3c. Wait for it to come up (5–10 min)
+
+```powershell
+kubectl -n spinnaker get spinnakerservice spinnaker -w
+# Ctrl+C once status settles, then:
+kubectl -n spinnaker get pods
+```
+
+When `spin-deck` and `spin-gate` pods are `Running`, get their public hostnames
+(these are AWS network load balancers):
+
+```powershell
+$DECK = kubectl -n spinnaker get svc spin-deck -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+$GATE = kubectl -n spinnaker get svc spin-gate -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+echo "Spinnaker UI:   http://$($DECK):9000"
+echo "Spinnaker Gate: http://$($GATE):8084"
+```
+
+Open `http://<deck-host>:9000` in a browser. No login (auth is disabled — see
+the warning below).
+
+> **Security:** auth is off. Lock down the NLB security groups to **your IP
+> only** before doing anything else. In the EC2 console → Load Balancers →
+> the two `spin-*` NLBs → their security groups → restrict inbound to your IP.
+
+---
+
+## Phase 4 — Provision the EMS application platform (ALB, ECS, RDS, ECR, secrets)
+
+```powershell
+cd ..\..\..\ems      # -> terraform\ems
+
+"aws_account_id = `"$ACCOUNT`"" | Out-File -Encoding ascii account.auto.tfvars
+
+terraform init
+terraform workspace new dev          # first time only
+terraform apply -var-file=envs\dev.tfvars    # review, type: yes
+```
+
+Save the outputs Spinnaker and you will reference:
+
+```powershell
+$ALB = (terraform output -raw alb_url)
+terraform output            # full list: cluster name, target groups, role names, ECR URI
+echo "App will be reachable at: $ALB"
+```
+
+Everything the Spinnaker pipeline references by name (target groups, IAM roles,
+security group, ECS cluster, log group) is created here. Don't rename one
+without the other.
+
+---
+
+## Phase 5 — Configure Spinnaker (one time)
+
+In the Deck UI (`http://<deck-host>:9000`):
+
+1. **Applications → Create Application**
+   - Name: `ems`
+   - Owner email: your email
+   - Cloud Providers: tick **Amazon Web Services** and **Amazon ECS**
+
+Then import the pipeline. Install the `spin` CLI (PowerShell):
+
+```powershell
+$spinDir = "$env:USERPROFILE\bin"
+New-Item -ItemType Directory -Force -Path $spinDir | Out-Null
+$ver = (Invoke-RestMethod "https://storage.googleapis.com/spinnaker-artifacts/spin/latest").Trim()
+Invoke-WebRequest "https://storage.googleapis.com/spinnaker-artifacts/spin/$ver/windows/amd64/spin.exe" `
+  -OutFile "$spinDir\spin.exe"
+$env:PATH = "$spinDir;$env:PATH"
+
+# Tell spin where Gate is
+"gate:`n  endpoint: http://$($GATE):8084" | Out-File -Encoding ascii "$env:USERPROFILE\.spin\config"
+
+# from the repo root:
+cd ..\..       # -> repo root
+spin pipeline save --file spinnaker\pipelines\ems-deploy-cicd.json
+```
+
+Refresh the UI → **ems → Pipelines** → you should see `ems-deploy-cicd`.
+
+---
+
+## Phase 6 — Wire GitHub Actions (the auto-deploy trigger)
+
+The workflow `.github/workflows/deploy.yml` is already in the repo. It needs
+three **variables** and one **secret** on GitHub.
+
+Go to **GitHub → your repo → Settings → Secrets and variables → Actions**:
+
+**Variables tab → New repository variable** (×3):
+
+| Name                | Value                                              |
+|---------------------|----------------------------------------------------|
+| `AWS_ROLE_ARN`      | the `$ROLE_ARN` from Phase 2                        |
+| `AWS_REGION`        | `us-east-1`                                         |
+| `SPINNAKER_GATE_URL`| `http://<gate-host>:8084`  (the `$GATE` from 3c, **no trailing slash**) |
+
+**Secrets tab → New repository secret** (×1):
+
+| Name                      | Value                                        |
+|---------------------------|----------------------------------------------|
+| `SPINNAKER_WEBHOOK_TOKEN` | any string, e.g. a GUID. (Not enforced while `webhooks.trust.enabled: false`, but the workflow sends it.) |
+
+> The Gate LoadBalancer SG must allow inbound from GitHub's runners for the
+> webhook to land. For a locked-down learning setup, either (a) temporarily
+> widen the Gate NLB SG to `0.0.0.0/0` on port 8084 only while testing, or
+> (b) trigger the Spinnaker pipeline manually from the UI and skip the webhook.
+> GitHub publishes its runner IP ranges at `https://api.github.com/meta` if you
+> want to scope it tightly.
+
+---
+
+## Phase 7 — Deploy by pushing to main
+
+From your laptop:
+
+```powershell
+cd practice
+# make a change, e.g. edit README, then:
+git add .
+git commit -m "test: trigger first auto-deploy"
+git push origin main
+```
+
+Watch the loop:
+
+1. **GitHub → Actions tab** — the `deploy` workflow runs: test → Jib build/push
+   → "Trigger Spinnaker pipeline". ~3–6 min.
+2. **Spinnaker UI → ems → Pipelines** — an execution starts. For a `main` push
+   it runs Deploy Dev → Smoke Dev (and the prod stages gate on Manual Judgment).
+3. **AWS Console → ECS → `ems-dev` cluster** — a new service/task revision
+   appears and reaches `RUNNING`.
+4. **Verify it's live:**
+   ```powershell
+   curl "$ALB/actuator/health"      # -> {"status":"UP"}
+   ```
+
+That's the full CI/CD loop. Every subsequent `git push origin main` repeats
+steps 1–4 automatically.
+
+---
+
+## Phase 8 — Rollback
+
+In the Spinnaker UI → **ems → Clusters**, select the previous server group →
+**Enable**, then disable the bad one. Red/black keeps the prior version around
+(`maxRemainingAsgs=2`) specifically for this one-click rollback. Nothing to
+script.
+
+---
+
+## Phase 9 — Tear down (stop the meter)
+
+Reverse order. App platform first, then the control plane.
+
+```powershell
+# EMS platform
+cd terraform\ems
+terraform destroy -var-file=envs\dev.tfvars     # type: yes
+
+# Spinnaker (delete the CR first so its NLBs are removed cleanly)
+kubectl -n spinnaker delete spinnakerservice spinnaker
+cd ..\spinnaker
+terraform destroy                                # type: yes
+```
+
+> If `terraform destroy` on the spinnaker root hangs on the VPC/subnets, it's
+> usually leftover ELBs from the SpinnakerService — make sure the `kubectl
+> delete spinnakerservice` above completed and the `spin-*` load balancers are
+> gone from the EC2 console, then re-run destroy.
+
+The S3 state bucket and DynamoDB lock table from Phase 1 are intentionally not
+destroyed — they're cheap and reusable. Delete them by hand if you're truly done.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| Actions step "Configure AWS credentials" fails with `Not authorized to perform sts:AssumeRoleWithWebIdentity` | `AWS_ROLE_ARN` variable wrong, or you pushed from a branch other than `main` (trust is scoped to `main`). |
+| Jib push fails `denied: not authorized` | The `github-actions-ems` role's ECR policy is in `terraform/spinnaker` — make sure Phase 2 applied cleanly. |
+| Spinnaker execution never starts after Actions succeeds | `SPINNAKER_GATE_URL` wrong, or the Gate NLB SG is blocking GitHub runners (see Phase 6 note). Test the webhook reachability or trigger manually in the UI. |
+| ECS task stuck `PENDING` then dies | Check **CloudWatch → /ecs/ems-dev** logs. Usually a DB connection failure — confirm the RDS SG allows the tasks SG and the `DB_*` SSM params resolved. |
+| `terraform apply` errors `bucket already exists` | Someone has that global S3 name. Rename per the Phase 1 note. |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and a Jenkins → Jib → Spinnaker CI/CD pipeline targeting ECS Fargate.
 | Build          | Maven Wrapper                                                |
 | Container      | Jib in CI, Dockerfile fallback for local debug               |
 | Infra          | Terraform (ECS Fargate platform; Spinnaker owns services)    |
-| CI / CD        | Jenkins → Jib → ECR → Spinnaker → ECS Fargate                |
+| CI / CD        | GitHub Actions → Jib → ECR → Spinnaker → ECS Fargate (Jenkinsfile kept as alt) |
 | Observability  | Actuator, Micrometer (Prometheus), structured JSON logs      |
 
 ## Quick start (local dev)
@@ -37,6 +37,10 @@ When done:
 ```
 
 ## Deploy
+
+> **Full walkthrough (Windows, infra → app):** [`DEPLOY-WINDOWS.md`](DEPLOY-WINDOWS.md)
+> covers the whole thing end to end — bootstrap, Spinnaker on EKS, EMS platform,
+> GitHub Actions wiring, and the push-to-main auto-deploy loop.
 
 Two-step ownership model:
 
@@ -57,9 +61,10 @@ for load tests. See [`performance/README.md`](performance/README.md) for the
 JMeter plan and BlazeMeter wiring.
 
 **3. EMS application (Spinnaker).** Provisions ECS services and task
-definitions. Triggered automatically by every push to `develop` or `main`
-via Jenkins. First time: import the pipeline once with `spin pipeline save`.
-Details in [`spinnaker/README.md`](spinnaker/README.md).
+definitions. Triggered automatically by every push to `main` via GitHub
+Actions (`.github/workflows/deploy.yml`), which builds the image and POSTs the
+Spinnaker webhook. First time: import the pipeline once with `spin pipeline
+save`. Details in [`spinnaker/README.md`](spinnaker/README.md).
 
 CI/CD architecture and end-to-end flow are documented in [`CICD.md`](CICD.md).
 

--- a/terraform/spinnaker/github_oidc.tf
+++ b/terraform/spinnaker/github_oidc.tf
@@ -1,0 +1,98 @@
+# ---------------------------------------------------------------------------
+# GitHub Actions OIDC trust.
+#
+# Lets the deploy workflow (.github/workflows/deploy.yml) assume a short-lived
+# AWS role with NO static access keys stored in GitHub. Trust is scoped to
+# pushes on the `main` branch of the repo below — a token minted for any other
+# repo, branch, or a pull_request event cannot assume this role.
+#
+# Lives in the spinnaker root (not ems) because an OIDC provider is
+# account-global: only one provider per URL per AWS account. The role only
+# needs to push images to the `ems` ECR repo; triggering Spinnaker is an
+# outbound HTTPS call from the runner and needs no AWS permission.
+#
+# After `terraform apply`, copy the `github_actions_role_arn` output into the
+# GitHub repo's Actions variables as AWS_ROLE_ARN.
+# ---------------------------------------------------------------------------
+
+variable "github_repo" {
+  description = "GitHub <owner>/<repo> whose main branch may assume the CI role."
+  type        = string
+  default     = "sarkr72/practice"
+}
+
+# Pull GitHub's current OIDC signing cert so the thumbprint never goes stale.
+data "tls_certificate" "github" {
+  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.github.certificates[0].sha1_fingerprint]
+}
+
+data "aws_iam_policy_document" "github_actions_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # Only main-branch pushes. Use "repo:${var.github_repo}:*" if you later
+    # want tags or other branches to deploy too.
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_repo}:ref:refs/heads/main"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions" {
+  name               = "github-actions-ems"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume.json
+}
+
+# Minimal ECR push permissions, scoped to the ems repository.
+# GetAuthorizationToken is account-wide by API design (resource must be "*").
+data "aws_iam_policy_document" "github_actions" {
+  statement {
+    sid       = "EcrAuth"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "EcrPushPull"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:PutImage",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+    resources = ["arn:aws:ecr:${var.aws_region}:${var.aws_account_id}:repository/ems"]
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions" {
+  name   = "github-actions-ems-ecr"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.github_actions.json
+}
+
+output "github_actions_role_arn" {
+  description = "Set this as the AWS_ROLE_ARN variable in GitHub > Settings > Actions."
+  value       = aws_iam_role.github_actions.arn
+}

--- a/terraform/spinnaker/manifests/spinnaker/README.md
+++ b/terraform/spinnaker/manifests/spinnaker/README.md
@@ -10,12 +10,9 @@ Run from this directory after `terraform apply` in `terraform/spinnaker`:
 ```bash
 # Pull every value the manifest needs
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-export AWS_REGION=$(terraform -chdir=../../ output -raw -json 2>/dev/null \
-  | jq -r '.cluster_endpoint.value' | awk -F'[/.]' '{print $5}')
+export AWS_REGION=us-east-1
 export SPINNAKER_ROLE_ARN=$(terraform -chdir=../../ output -raw spinnaker_role_arn)
 export PERSISTENCE_BUCKET=$(terraform -chdir=../../ output -raw persistence_bucket)
-export JENKINS_BASE_URL="${JENKINS_BASE_URL:-http://jenkins.example.internal}"
-export JENKINS_WEBHOOK_TOKEN="${JENKINS_WEBHOOK_TOKEN:-changeme}"
 
 envsubst < spinnakerservice.yaml > /tmp/spinnakerservice.rendered.yaml
 ```
@@ -51,5 +48,9 @@ Visit `http://<that-hostname>:9000`. No login — see the security warning in
 spin pipeline save --file ../../../../spinnaker/pipelines/ems-deploy-cicd.json
 ```
 
-The pipeline references account names `aws-dev` and `aws-prod-ecs` defined
-in the SpinnakerService above. Reconcile any name changes before importing.
+The pipeline references account names `aws-dev` and `aws-prod` defined in the
+SpinnakerService above. Reconcile any name changes before importing.
+
+> **Windows users:** `envsubst` isn't available by default. Use the PowerShell
+> rendering steps in [`DEPLOY-WINDOWS.md`](../../../../DEPLOY-WINDOWS.md) instead
+> of the bash block above — everything else on this page is the same.

--- a/terraform/spinnaker/manifests/spinnaker/spinnakerservice.yaml
+++ b/terraform/spinnaker/manifests/spinnaker/spinnakerservice.yaml
@@ -7,8 +7,9 @@
 #   __AWS_REGION__            e.g. us-east-1
 #   __SPINNAKER_ROLE_ARN__    output: spinnaker_role_arn
 #   __PERSISTENCE_BUCKET__    output: persistence_bucket
-#   __JENKINS_BASE_URL__      e.g. http://jenkins.example.internal
-#   __JENKINS_WEBHOOK_TOKEN__ shared token; same value lives in Jenkins creds
+#
+# CI is GitHub Actions (.github/workflows/deploy.yml): Actions builds the image
+# and POSTs the inbound webhook below, so no Jenkins/igor master is configured.
 #
 # Auth: disabled. Anyone reaching Deck's LoadBalancer can drive Spinnaker.
 # This is a learning setup — restrict the LB SG to your IP, or front it with
@@ -61,14 +62,10 @@ spec:
           enabled: true
           accounts:
             - name: ecr-artifacts
-      ci:
-        jenkins:
-          enabled: true
-          masters:
-            - name: jenkins
-              address: __JENKINS_BASE_URL__
-              username: spinnaker
-              password: __JENKINS_WEBHOOK_TOKEN__
+      # Inbound webhook trigger from GitHub Actions. trust.enabled=false means
+      # the X-Spinnaker-Token header is not enforced — fine for a learning
+      # setup where the Gate LoadBalancer SG is locked to your IP. Set it to
+      # true and add a `webhooks.preflight` secret to require the token.
       webhooks:
         trust:
           enabled: false

--- a/terraform/spinnaker/providers.tf
+++ b/terraform/spinnaker/providers.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
   }
 
   # Shares the rinku-tfstate-001 bucket with terraform/ems but under a


### PR DESCRIPTION
Wires the missing CI trigger so a push to main builds the image and kicks the Spinnaker ECS Fargate deploy, with no AWS keys in GitHub.

- .github/workflows/deploy.yml: on push to main, assume AWS via OIDC, run tests, Jib build/push to ECR, POST the Spinnaker webhook.
- terraform/spinnaker/github_oidc.tf: GitHub OIDC provider + scoped github-actions-ems role (ECR push only, main branch only).
- spinnakerservice.yaml: drop the Jenkins/igor CI block (GitHub Actions is the trigger now); keep inbound webhook trust disabled for learning.
- DEPLOY-WINDOWS.md: full PowerShell runbook, infra -> app, incl. bootstrap, Spinnaker on EKS, platform apply, GitHub wiring, deploy, rollback, teardown, troubleshooting.
- README/CICD/manifest READMEs: point at the GitHub Actions path and the Windows runbook; Jenkins kept as documented alternative.