### PR TITLE
Add manual infrastructure workflow with separate OIDC role

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,103 @@
+# INFRA workflow — runs Terraform, MANUALLY only.
+#
+# This NEVER runs on a code push. The only trigger is `workflow_dispatch`,
+# i.e. you go to the Actions tab -> "infra" -> "Run workflow", pick a stack /
+# action / env, and click the button. Pushing app code does nothing here.
+#
+# This is the separation you want: app deploys are automatic (deploy.yml),
+# infra changes are deliberate and human-initiated (this file).
+#
+# Required GitHub config (Settings -> Secrets and variables -> Actions):
+#   Variables:
+#     AWS_INFRA_ROLE_ARN   terraform output github_actions_infra_role_arn
+#     AWS_REGION           us-east-1
+#
+# First-run note: the AWS_INFRA_ROLE_ARN role is itself created by Terraform,
+# so the very first `terraform apply` of the spinnaker stack must be run from
+# your laptop (see DEPLOY-WINDOWS.md). After that, use this button for
+# everything.
+
+name: infra
+
+on:
+  workflow_dispatch:
+    inputs:
+      stack:
+        description: "Which Terraform root to run"
+        type: choice
+        options:
+          - ems
+          - spinnaker
+        required: true
+      action:
+        description: "plan (preview, safe) or apply (make changes)"
+        type: choice
+        options:
+          - plan
+          - apply
+        default: plan
+        required: true
+      env:
+        description: "Environment (ems stack only; ignored for spinnaker)"
+        type: choice
+        options:
+          - dev
+          - perf
+          - prod
+        default: dev
+        required: true
+
+permissions:
+  id-token: write     # for OIDC role assumption
+  contents: read
+
+# Never let two infra runs collide.
+concurrency:
+  group: infra-${{ inputs.stack }}-${{ inputs.env }}
+  cancel-in-progress: false
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_INFRA_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Terraform ${{ inputs.action }} (${{ inputs.stack }})
+        working-directory: terraform/${{ inputs.stack }}
+        run: |
+          set -euo pipefail
+
+          # account.auto.tfvars is gitignored, so supply the account id from STS.
+          export TF_VAR_aws_account_id="$(aws sts get-caller-identity --query Account --output text)"
+
+          terraform init -input=false
+
+          # The ems stack is per-environment (workspaces + tfvars); spinnaker is single.
+          if [ "${{ inputs.stack }}" = "ems" ]; then
+            terraform workspace select "${{ inputs.env }}" 2>/dev/null \
+              || terraform workspace new "${{ inputs.env }}"
+            VAR_ARGS="-var-file=envs/${{ inputs.env }}.tfvars"
+          else
+            VAR_ARGS=""
+          fi
+
+          if [ "${{ inputs.action }}" = "apply" ]; then
+            terraform apply -input=false -auto-approve $VAR_ARGS
+          else
+            terraform plan -input=false $VAR_ARGS
+          fi
+
+      - name: Summary
+        run: |
+          echo "### Terraform ${{ inputs.action }} — ${{ inputs.stack }} ${{ inputs.env }}" >> $GITHUB_STEP_SUMMARY
+          echo "Triggered manually by @${{ github.actor }}." >> $GITHUB_STEP_SUMMARY

--- a/terraform/spinnaker/github_oidc.tf
+++ b/terraform/spinnaker/github_oidc.tf
@@ -96,3 +96,39 @@ output "github_actions_role_arn" {
   description = "Set this as the AWS_ROLE_ARN variable in GitHub > Settings > Actions."
   value       = aws_iam_role.github_actions.arn
 }
+
+# ---------------------------------------------------------------------------
+# Separate role for the INFRA workflow (.github/workflows/infra.yml).
+#
+# Why a second role: running `terraform apply` creates EKS, RDS, IAM roles,
+# VPC plumbing, etc. — that needs broad permissions, unlike the app deploy
+# which only pushes an image. Keeping them as two roles means a leaked app
+# token can never run terraform, and vice-versa (least privilege by separation).
+#
+# SECURITY NOTE: this attaches AdministratorAccess. That is acceptable here
+# because (a) it's a personal learning account, and (b) infra.yml is
+# `workflow_dispatch` only — it can ONLY be started by a human clicking "Run
+# workflow", never by a code push. The trust below still restricts it to the
+# main branch of this one repo. For a real org, replace AdministratorAccess
+# with a scoped policy (or run infra from a separate repo/account entirely).
+#
+# Chicken-and-egg: this role is created BY terraform, so the FIRST
+# `terraform apply` of this spinnaker root must be run from your laptop. After
+# that, copy `github_actions_infra_role_arn` into the AWS_INFRA_ROLE_ARN
+# GitHub variable and manage all later changes from the infra.yml button.
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "github_actions_infra" {
+  name               = "github-actions-ems-infra"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions_infra_admin" {
+  role       = aws_iam_role.github_actions_infra.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+output "github_actions_infra_role_arn" {
+  description = "Set this as the AWS_INFRA_ROLE_ARN variable in GitHub > Settings > Actions."
+  value       = aws_iam_role.github_actions_infra.arn
+}


### PR DESCRIPTION
## Summary
This PR introduces a manual GitHub Actions workflow for infrastructure management via Terraform, along with a dedicated IAM role for infrastructure operations. This separates infrastructure changes from application deployments, ensuring that infrastructure modifications are always human-initiated and deliberate.

## Key Changes
- **New workflow**: `.github/workflows/infra.yml` — a `workflow_dispatch`-only workflow that allows manual Terraform `plan` and `apply` operations
  - Supports two stacks: `ems` (multi-environment via workspaces) and `spinnaker` (single environment)
  - Requires explicit selection of action (plan/apply) and environment (dev/perf/prod for ems)
  - Uses OIDC role assumption for AWS credentials
  - Enforces concurrency to prevent simultaneous runs on the same stack/environment
  
- **New IAM role**: `github_actions_infra` in `terraform/spinnaker/github_oidc.tf`
  - Separate from the existing app deployment role to enforce least privilege by separation
  - Attached with `AdministratorAccess` policy (acceptable for personal learning account with manual-only trigger)
  - Restricted to main branch via existing trust policy
  - Outputs `github_actions_infra_role_arn` for GitHub Actions configuration

## Implementation Details
- The workflow automatically derives the AWS account ID from STS to populate `account.auto.tfvars` (which is gitignored)
- For the `ems` stack, it selects or creates a Terraform workspace matching the selected environment
- The `spinnaker` stack ignores the environment input and runs without workspace/tfvar selection
- Includes bootstrap note: the first `terraform apply` of the spinnaker stack must be run locally since the role is created by Terraform itself
- Workflow summary is posted to GitHub Actions for audit trail

https://claude.ai/code/session_014F6umrv1Uoj7W5GxkK84K4