### PR TITLE
Restrict EKS subnets to supported availability zones

### DIFF
--- a/terraform/spinnaker/data.tf
+++ b/terraform/spinnaker/data.tf
@@ -9,6 +9,13 @@ data "aws_subnets" "default" {
     name   = "vpc-id"
     values = [data.aws_vpc.default.id]
   }
+
+  # EKS control planes cannot run in us-east-1e. Restrict to the AZs EKS
+  # supports so the default-VPC subnet in 1e isn't handed to the cluster.
+  filter {
+    name   = "availability-zone"
+    values = ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1f"]
+  }
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
## Summary
Added an availability zone filter to the default VPC subnet data source to prevent EKS control planes from being placed in unsupported zones.

## Key Changes
- Added an availability zone filter to `data.aws_subnets.default` that restricts subnet selection to zones supported by EKS (us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1f)
- This prevents the default VPC subnet in us-east-1e from being assigned to the EKS cluster, as EKS control planes cannot run in that availability zone

## Implementation Details
The filter ensures that when Terraform queries for subnets in the default VPC, only those in EKS-compatible availability zones are returned. This avoids potential cluster creation failures or misconfigurations that could occur if a subnet in the unsupported us-east-1e zone was selected.

https://claude.ai/code/session_014F6umrv1Uoj7W5GxkK84K4