### PR TITLE
Fix CI: remove invalid spring.profiles.active from application-test.properties

### DIFF
--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,4 +1,3 @@
-spring.profiles.active=test
 spring.test.database.replace=none
 spring.main.allow-bean-definition-overriding=true
 


### PR DESCRIPTION
CI build failed with `InvalidConfigDataPropertyException: Property 'spring.profiles.active' imported from location 'class path resource [application-test.properties]' is invalid in a profile specific resource`.

Spring Boot 2.4+ forbids setting `spring.profiles.active` inside a profile-specific config file — `application-test.properties` already *is* the test profile, so activating itself is circular. The profile is properly activated by `@ActiveProfiles("test")` on the test classes / `SPRING_PROFILES_ACTIVE` in CI.

Drop that one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014F6umrv1Uoj7W5GxkK84K4)_