### PR TITLE
Fix: add missing required ECS fields to dev-only pipeline

### DIFF
--- a/spinnaker/pipelines/ems-deploy-dev-only.json
+++ b/spinnaker/pipelines/ems-deploy-dev-only.json
@@ -59,6 +59,11 @@
       "platformVersion": "LATEST",
       "computeUnits": 512,
       "reservedMemory": 1024,
+      "availabilityZones": {
+        "us-east-1": ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1d", "us-east-1f"]
+      },
+      "placementStrategySequence": [],
+      "dockerImageAddress": "${parameters.ecrRegistry}/${parameters.ecrRepo}:${parameters.imageTag}",
       "containerInformation": {
         "imageDescription": {
           "imageId":    "${parameters.ecrRegistry}/${parameters.ecrRepo}:${parameters.imageTag}",


### PR DESCRIPTION
Spinnaker's ECS `createServerGroup` validator threw three "not nullable" errors:

```
createServerGroupDescription.availabilityZones.not.nullable
createServerGroupDescription.placementStrategySequence.not.nullable
createServerGroupDescription.dockerImageAddress.not.nullable
```

Adds them at the stage's top level:
- `availabilityZones` — region-keyed map of AZs (excluding `us-east-1e` to match the EKS-supported set).
- `placementStrategySequence` — empty list, fine for Fargate.
- `dockerImageAddress` — top-level image ref alongside `containerInformation.imageDescription`.

After merge, re-import the pipeline with `spin pipeline save --file spinnaker\pipelines\ems-deploy-dev-only.json` and re-trigger the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014F6umrv1Uoj7W5GxkK84K4)_