### PR TITLE
Add iam:GetRole to spinnaker-managed inline policy

### DIFF
--- a/terraform/spinnaker/iam.tf
+++ b/terraform/spinnaker/iam.tf
@@ -58,8 +58,9 @@ data "aws_iam_policy_document" "spinnaker_inline" {
 
   statement {
     sid     = "PassEcsTaskRoles"
-    actions = ["iam:PassRole"]
-    # Spinnaker passes the ems task / task-execution roles into ECS RunTask.
+    actions = ["iam:PassRole", "iam:GetRole"]
+    # Spinnaker passes the ems task / task-execution roles into ECS RunTask,
+    # and calls GetRole on them while validating the task definition.
     resources = [
       "arn:aws:iam::${var.aws_account_id}:role/ems-*-task",
       "arn:aws:iam::${var.aws_account_id}:role/ems-*-task-exec",


### PR DESCRIPTION
Spinnaker calls `iam:GetRole` (not just `PassRole`) on the ems task / task-exec roles while validating the ECS task definition. Without it, `Monitor Deploy` fails with `AccessDenied iam:GetRole on resource: role ems-dev-task-exec`.

Scoped to the same `ems-*-task*` ARNs as `PassRole`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014F6umrv1Uoj7W5GxkK84K4)_