### PR TITLE
Grant inventory perms to Spinnaker caching agents

### DIFF
--- a/terraform/spinnaker/iam.tf
+++ b/terraform/spinnaker/iam.tf
@@ -68,8 +68,50 @@ data "aws_iam_policy_document" "spinnaker_inline" {
   }
 
   statement {
-    sid       = "ReadConfigForTaskDefs"
-    actions   = ["ssm:GetParameter", "ssm:GetParameters", "secretsmanager:GetSecretValue"]
+    sid     = "ReadConfigForTaskDefs"
+    actions = ["ssm:GetParameter", "ssm:GetParameters", "secretsmanager:GetSecretValue"]
+    resources = ["*"]
+  }
+
+  # Spinnaker's caching agents (SecretCachingAgent, AmazonCertificateCachingAgent,
+  # etc.) inventory the account every minute. Without these List/Describe calls,
+  # the caches stay null and the ECS createServerGroup validator NPEs with
+  # "Cannot invoke Collection.size() because c is null".
+  statement {
+    sid     = "CachingAgentInventory"
+    actions = [
+      "secretsmanager:ListSecrets",
+      "secretsmanager:DescribeSecret",
+      "acm:ListCertificates",
+      "acm:DescribeCertificate",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeVpcs",
+      "ec2:DescribeInstances",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeKeyPairs",
+      "ec2:DescribeImages",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeTargetGroups",
+      "elasticloadbalancing:DescribeListeners",
+      "elasticloadbalancing:DescribeRules",
+      "elasticloadbalancing:DescribeTags",
+      "iam:ListRoles",
+      "iam:ListInstanceProfiles",
+      "iam:ListServerCertificates",
+      "ecs:ListClusters",
+      "ecs:DescribeClusters",
+      "ecs:ListServices",
+      "ecs:DescribeServices",
+      "ecs:ListTasks",
+      "ecs:DescribeTasks",
+      "ecs:ListTaskDefinitions",
+      "ecs:DescribeTaskDefinition",
+      "ecs:ListContainerInstances",
+      "ecs:DescribeContainerInstances",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
     resources = ["*"]
   }
 


### PR DESCRIPTION
SecretCachingAgent + AmazonCertificateCachingAgent (and several other Spinnaker caching agents) need `List*`/`Describe*` calls across the account every minute. Without them, their caches stay empty/null and the ECS `createServerGroup` validator NPEs:

> `Cannot invoke "java.util.Collection.size()" because "c" is null`

Adds a `CachingAgentInventory` statement covering:
- Secrets Manager: `ListSecrets`, `DescribeSecret`
- ACM: `ListCertificates`, `DescribeCertificate`
- EC2: SGs, subnets, VPCs, instances, AZs, key pairs, images
- ELBv2: load balancers, target groups, listeners, rules, tags
- IAM: list roles / instance profiles / server certificates
- ECS: list+describe clusters/services/tasks/task definitions/container instances
- CloudWatch Logs: log groups/streams

Read-only, account-scoped (these APIs require `resources: "*"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014F6umrv1Uoj7W5GxkK84K4)_