### PR TITLE
Bake spinnaker-managed self-trust into terraform

### DIFF
--- a/terraform/spinnaker/iam.tf
+++ b/terraform/spinnaker/iam.tf
@@ -26,6 +26,17 @@ data "aws_iam_policy_document" "spinnaker_assume" {
       values   = ["sts.amazonaws.com"]
     }
   }
+
+  # Allow the role to assume itself. Spinnaker's clouddriver re-assumes its
+  # own role at deploy time (per-account assumeRole pattern). Without this,
+  # the deploy stage fails with AccessDenied on sts:AssumeRole.
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.aws_account_id}:role/spinnaker-managed"]
+    }
+  }
 }
 
 resource "aws_iam_role" "spinnaker" {


### PR DESCRIPTION
Clouddriver re-assumes its own role at deploy time (per-account `assumeRole` config in SpinnakerService). We patched this by hand in the AWS console earlier; the next `terraform apply` silently reverted it, breaking the deploy stage with `AccessDenied on sts:AssumeRole`.

Bake the self-trust into `iam.tf` so future applies preserve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014F6umrv1Uoj7W5GxkK84K4)_