### PR TITLE
Auto-discover Fargate subnet/SG IDs at deploy time (no hardcoding)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,27 @@ jobs:
           -Djib.to.image=${{ steps.ecr.outputs.registry }}/ems:${{ github.sha }}
           -Djib.to.tags=latest
 
+      # Discover the Fargate networking IDs at deploy time. The pipeline JSON
+      # references these via ${parameters.subnetIds} / ${parameters.securityGroupId}
+      # so we never need to (a) hardcode IDs in the JSON or (b) register a
+      # clouddriver-side subnet attribute in SpinnakerService.
+      - name: Resolve subnet + security group IDs for Fargate
+        id: net
+        run: |
+          set -euo pipefail
+          SG_ID=$(aws ec2 describe-security-groups \
+            --filters "Name=group-name,Values=ems-dev-tasks" \
+            --query "SecurityGroups[0].GroupId" --output text)
+          # Default VPC, AZs that EKS+ECS both support (excludes us-east-1e).
+          SUBNET_IDS=$(aws ec2 describe-subnets \
+            --filters "Name=vpc-id,Values=$(aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text)" \
+                      "Name=availability-zone,Values=us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1f" \
+            --query "Subnets[].SubnetId" --output text | tr '\t' ',')
+          echo "sg_id=$SG_ID"           >> "$GITHUB_OUTPUT"
+          echo "subnet_ids=$SUBNET_IDS" >> "$GITHUB_OUTPUT"
+          echo "Resolved SG  = $SG_ID"
+          echo "Resolved SNs = $SUBNET_IDS"
+
       - name: Trigger Spinnaker pipeline
         run: |
           curl -fsS -X POST "${{ vars.SPINNAKER_GATE_URL }}/webhooks/webhook/ems-build-complete" \
@@ -70,11 +91,13 @@ jobs:
             -d "$(cat <<JSON
           {
             "parameters": {
-              "imageTag":    "${{ github.sha }}",
-              "branch":      "main",
-              "ecrRegistry": "${{ steps.ecr.outputs.registry }}",
-              "ecrRepo":     "ems",
-              "buildUrl":    "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              "imageTag":         "${{ github.sha }}",
+              "branch":           "main",
+              "ecrRegistry":      "${{ steps.ecr.outputs.registry }}",
+              "ecrRepo":          "ems",
+              "buildUrl":         "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "subnetIds":        "${{ steps.net.outputs.subnet_ids }}",
+              "securityGroupId":  "${{ steps.net.outputs.sg_id }}"
             }
           }
           JSON

--- a/spinnaker/pipelines/ems-deploy-dev-only.json
+++ b/spinnaker/pipelines/ems-deploy-dev-only.json
@@ -27,12 +27,14 @@
   "limitConcurrent": true,
 
   "parameterConfig": [
-    { "name": "imageTag",    "required": true,  "description": "ECR image tag built by GitHub Actions" },
-    { "name": "branch",      "required": false, "description": "Source branch", "default": "main" },
-    { "name": "appId",       "required": false, "default": "APP-EMS-UNASSIGNED" },
-    { "name": "buildUrl",    "required": false, "description": "Link back to the GitHub Actions run" },
-    { "name": "ecrRegistry", "required": true,  "description": "<account>.dkr.ecr.<region>.amazonaws.com" },
-    { "name": "ecrRepo",     "required": false, "default": "ems" }
+    { "name": "imageTag",       "required": true,  "description": "ECR image tag built by GitHub Actions" },
+    { "name": "branch",         "required": false, "description": "Source branch", "default": "main" },
+    { "name": "appId",          "required": false, "default": "APP-EMS-UNASSIGNED" },
+    { "name": "buildUrl",       "required": false, "description": "Link back to the GitHub Actions run" },
+    { "name": "ecrRegistry",    "required": true,  "description": "<account>.dkr.ecr.<region>.amazonaws.com" },
+    { "name": "ecrRepo",        "required": false, "default": "ems" },
+    { "name": "subnetIds",      "required": true,  "description": "Comma-separated subnet IDs for the Fargate tasks. Resolved by GitHub Actions from AWS so no clouddriver subnet-type registration is needed." },
+    { "name": "securityGroupId","required": true,  "description": "Security group ID (sg-...) for the Fargate tasks. Resolved by GitHub Actions." }
   ],
 
   "triggers": [
@@ -81,8 +83,8 @@
         }
       ],
       "networkMode": "awsvpc",
-      "subnetType":  "ecs-tasks-dev",
-      "securityGroups": ["ems-dev-tasks"],
+      "subnetType":  "${parameters.subnetIds}",
+      "securityGroups": ["${parameters.securityGroupId}"],
       "associatePublicIpAddress": true,
       "iamRole":              "ems-dev-task-exec",
       "taskRoleArn":          "ems-dev-task",

--- a/terraform/spinnaker/github_oidc.tf
+++ b/terraform/spinnaker/github_oidc.tf
@@ -84,6 +84,19 @@ data "aws_iam_policy_document" "github_actions" {
     ]
     resources = ["arn:aws:ecr:${var.aws_region}:${var.aws_account_id}:repository/ems"]
   }
+
+  # Read-only lookup of the Fargate networking IDs at deploy time so the
+  # Spinnaker pipeline doesn't need them hardcoded. Used by the "Resolve
+  # subnet + security group IDs" step in deploy.yml.
+  statement {
+    sid = "DescribeNetworkingForDeploy"
+    actions = [
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeVpcs",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_role_policy" "github_actions" {


### PR DESCRIPTION
Avoids hardcoding env-specific AWS IDs in the pipeline JSON, and avoids needing a clouddriver-side `ecs.subnetTypes` registration in SpinnakerService. The pipeline now reads its networking from parameters that GitHub Actions resolves fresh on every deploy.

## Changes

- **Pipeline JSON** (`ems-deploy-dev-only.json`): `subnetType` and `securityGroups` now reference `${parameters.subnetIds}` and `${parameters.securityGroupId}`. Two new required parameters in `parameterConfig`.
- **`deploy.yml`**: new "Resolve subnet + security group IDs" step uses `aws ec2 describe-*` to look up the SG by name (`ems-dev-tasks`) and the default-VPC subnets in EKS+ECS-supported AZs (excludes `us-east-1e`), then passes them in the webhook payload.
- **`github_oidc.tf`**: grant the `github-actions-ems` role `ec2:DescribeSecurityGroups`, `ec2:DescribeSubnets`, `ec2:DescribeVpcs` (read-only, account-wide) so the lookup step can run.

## After merge

```powershell
git pull origin main
cd terraform\spinnaker
·t·erraform a·pply               # picks up the new EC2 Describe perms
cd ..\..
spin pipeline save --file spinnaker\pipelines\ems-deploy-dev-only.json
git commit --allow-empty -m "deploy with auto-discovered network ids"
git push origin main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014F6umrv1Uoj7W5GxkK84K4)_