### PR TITLE
Switch deploy path to direct ECS (professional, repeatable, works first time)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,31 +1,47 @@
-# Push to main  ->  build image (Jib -> ECR)  ->  trigger Spinnaker  ->  ECS Fargate.
+# Push to main  ->  build image (Jib -> ECR)  ->  deploy to ECS Fargate.
 #
-# No AWS keys are stored in GitHub: the job mints a short-lived credential by
-# assuming the `github-actions-ems` role via OIDC (see terraform/spinnaker/
-# github_oidc.tf). Spinnaker performs the actual ECS deploy after the webhook.
+# The actual deployer is `aws ecs` (register-task-definition + update-service).
+# This was chosen over Spinnaker's createServerGroup after running into long-
+# standing Spinnaker-on-ECS limitations (EcsSecurityGroupCachingAgent doesn't
+# populate, so SecurityGroupSelector NPEs even with explicit IDs). Direct ECS
+# is what most teams use in production for Fargate workloads; Spinnaker is
+# best at Kubernetes.
+#
+# Idempotent: works on the FIRST push (creates the service) and every push
+# after (updates it). Deletes nothing. ECS handles the rolling deploy via its
+# own deployment controller — no Spinnaker stages required.
+#
+# No AWS keys are stored in GitHub: the job mints short-lived credentials by
+# assuming the `github-actions-ems` role via OIDC.
 #
 # Required GitHub config (Settings -> Secrets and variables -> Actions):
 #   Variables:
-#     AWS_ROLE_ARN          terraform output github_actions_role_arn
-#     AWS_REGION            us-east-1
-#     SPINNAKER_GATE_URL    http://<spin-gate-loadbalancer-host>   (no trailing slash)
-#   Secrets:
-#     SPINNAKER_WEBHOOK_TOKEN   any shared string; must match echo.webhooks.defaultSecret
+#     AWS_ROLE_ARN   terraform output github_actions_role_arn (terraform/spinnaker)
+#     AWS_REGION     us-east-1
 
 name: deploy
 
 on:
   push:
     branches: [main]
-  workflow_dispatch:        # lets you trigger a deploy by hand from the Actions tab
+  workflow_dispatch:        # manual trigger from the Actions tab
 
 permissions:
   id-token: write           # required for OIDC role assumption
   contents: read
 
-concurrency:                # one deploy at a time; newer push cancels an in-flight one
+concurrency:                # one deploy at a time
   group: deploy-main
   cancel-in-progress: false
+
+env:
+  AWS_REGION:   us-east-1
+  CLUSTER:      ems-dev
+  SERVICE:      ems-dev
+  CONTAINER:    ems
+  TARGET_GROUP: ems-dev-stable
+  SG_NAME:      ems-dev-tasks
+  ECR_REPO:     ems
 
 jobs:
   build-and-deploy:
@@ -47,7 +63,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region:     ${{ vars.AWS_REGION }}
 
       - name: Log in to Amazon ECR
         id: ecr
@@ -59,52 +75,122 @@ jobs:
       - name: Build and push image with Jib
         run: >-
           ./mvnw -B -ntp compile jib:build
-          -Djib.to.image=${{ steps.ecr.outputs.registry }}/ems:${{ github.sha }}
+          -Djib.to.image=${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPO }}:${{ github.sha }}
           -Djib.to.tags=latest
 
-      # Discover the Fargate networking IDs at deploy time. The pipeline JSON
-      # references these via ${parameters.subnetIds} / ${parameters.securityGroupId}
-      # so we never need to (a) hardcode IDs in the JSON or (b) register a
-      # clouddriver-side subnet attribute in SpinnakerService.
-      - name: Resolve subnet + security group IDs for Fargate
-        id: net
+      # -----------------------------------------------------------------------
+      # Look up the networking + ALB target group + AWS account live, so the
+      # task def + service-create commands don't carry environment-specific IDs.
+      # -----------------------------------------------------------------------
+      - name: Discover AWS account, VPC, subnets, security group, target group
+        id: lookup
         run: |
           set -euo pipefail
+          ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+          VPC_ID=$(aws ec2 describe-vpcs \
+            --filters Name=isDefault,Values=true \
+            --query 'Vpcs[0].VpcId' --output text)
           SG_ID=$(aws ec2 describe-security-groups \
-            --filters "Name=group-name,Values=ems-dev-tasks" \
-            --query "SecurityGroups[0].GroupId" --output text)
-          # Default VPC, AZs that EKS+ECS both support (excludes us-east-1e).
+            --filters "Name=group-name,Values=${SG_NAME}" \
+            --query 'SecurityGroups[0].GroupId' --output text)
+          # AZs both EKS and ECS support (excludes us-east-1e).
           SUBNET_IDS=$(aws ec2 describe-subnets \
-            --filters "Name=vpc-id,Values=$(aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text)" \
+            --filters "Name=vpc-id,Values=${VPC_ID}" \
                       "Name=availability-zone,Values=us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1f" \
-            --query "Subnets[].SubnetId" --output text | tr '\t' ',')
-          echo "sg_id=$SG_ID"           >> "$GITHUB_OUTPUT"
-          echo "subnet_ids=$SUBNET_IDS" >> "$GITHUB_OUTPUT"
-          echo "Resolved SG  = $SG_ID"
-          echo "Resolved SNs = $SUBNET_IDS"
+            --query 'Subnets[].SubnetId' --output text | tr '\t' ',')
+          TG_ARN=$(aws elbv2 describe-target-groups \
+            --names "${TARGET_GROUP}" \
+            --query 'TargetGroups[0].TargetGroupArn' --output text)
+          {
+            echo "account=$ACCOUNT"
+            echo "vpc_id=$VPC_ID"
+            echo "sg_id=$SG_ID"
+            echo "subnet_ids=$SUBNET_IDS"
+            echo "tg_arn=$TG_ARN"
+          } >> "$GITHUB_OUTPUT"
+          echo "VPC=$VPC_ID  SG=$SG_ID  TG=$TG_ARN"
+          echo "Subnets: $SUBNET_IDS"
 
-      - name: Trigger Spinnaker pipeline
+      - name: Render task definition
+        run: |
+          set -euo pipefail
+          IMAGE="${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPO }}:${{ github.sha }}"
+          sed -e "s|__ACCOUNT__|${{ steps.lookup.outputs.account }}|g" \
+              -e "s|__IMAGE__|${IMAGE}|g" \
+              ecs/taskdef.dev.json.tpl > taskdef.json
+          echo "Rendered task definition:"
+          cat taskdef.json
+
+      - name: Register new task definition revision
+        id: register
+        run: |
+          set -euo pipefail
+          TD_ARN=$(aws ecs register-task-definition \
+            --cli-input-json file://taskdef.json \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+          echo "td_arn=$TD_ARN" >> "$GITHUB_OUTPUT"
+          echo "Registered: $TD_ARN"
+
+      - name: Create or update the ECS service (idempotent)
+        run: |
+          set -euo pipefail
+          STATUS=$(aws ecs describe-services \
+            --cluster "${CLUSTER}" \
+            --services "${SERVICE}" \
+            --query 'services[0].status' --output text 2>/dev/null || echo "MISSING")
+
+          if [ "$STATUS" = "ACTIVE" ]; then
+            echo "Service ${SERVICE} exists — rolling out new task definition"
+            aws ecs update-service \
+              --cluster "${CLUSTER}" \
+              --service "${SERVICE}" \
+              --task-definition "${{ steps.register.outputs.td_arn }}" \
+              --force-new-deployment \
+              > /dev/null
+          else
+            echo "Service ${SERVICE} does not exist — creating"
+            aws ecs create-service \
+              --cluster "${CLUSTER}" \
+              --service-name "${SERVICE}" \
+              --task-definition "${{ steps.register.outputs.td_arn }}" \
+              --desired-count 2 \
+              --launch-type FARGATE \
+              --platform-version LATEST \
+              --network-configuration "awsvpcConfiguration={subnets=[${{ steps.lookup.outputs.subnet_ids }}],securityGroups=[${{ steps.lookup.outputs.sg_id }}],assignPublicIp=ENABLED}" \
+              --load-balancers "targetGroupArn=${{ steps.lookup.outputs.tg_arn }},containerName=${CONTAINER},containerPort=8080" \
+              --health-check-grace-period-seconds 60 \
+              --deployment-configuration "maximumPercent=200,minimumHealthyPercent=100" \
+              > /dev/null
+          fi
+
+      - name: Wait for service to stabilize
+        run: |
+          echo "Waiting for tasks to roll out and pass ALB health checks..."
+          aws ecs wait services-stable \
+            --cluster "${CLUSTER}" \
+            --services "${SERVICE}"
+          echo "Deployment stable."
+
+      # -----------------------------------------------------------------------
+      # Optional: notify Spinnaker so the UI shows a deploy event. Best-effort
+      # only — a Spinnaker outage must not fail the deploy. Skipped entirely
+      # if SPINNAKER_GATE_URL is unset.
+      # -----------------------------------------------------------------------
+      - name: Notify Spinnaker (optional, best-effort)
+        if: ${{ vars.SPINNAKER_GATE_URL != '' }}
+        continue-on-error: true
         run: |
           curl -fsS -X POST "${{ vars.SPINNAKER_GATE_URL }}/webhooks/webhook/ems-build-complete" \
             -H "X-Spinnaker-Token: ${{ secrets.SPINNAKER_WEBHOOK_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "$(cat <<JSON
-          {
-            "parameters": {
-              "imageTag":         "${{ github.sha }}",
-              "branch":           "main",
-              "ecrRegistry":      "${{ steps.ecr.outputs.registry }}",
-              "ecrRepo":          "ems",
-              "buildUrl":         "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "subnetIds":        "${{ steps.net.outputs.subnet_ids }}",
-              "securityGroupId":  "${{ steps.net.outputs.sg_id }}"
-            }
-          }
-          JSON
-          )"
+            -d "{\"parameters\":{\"imageTag\":\"${{ github.sha }}\",\"branch\":\"main\",\"ecrRegistry\":\"${{ steps.ecr.outputs.registry }}\",\"ecrRepo\":\"${{ env.ECR_REPO }}\",\"buildUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}}" \
+            || echo "Spinnaker notify failed (non-fatal)."
 
       - name: Summary
         run: |
-          echo "### Deployed image" >> $GITHUB_STEP_SUMMARY
-          echo "\`${{ steps.ecr.outputs.registry }}/ems:${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "Spinnaker pipeline **ems-deploy-cicd** triggered." >> $GITHUB_STEP_SUMMARY
+          {
+            echo "### Deployed"
+            echo "Image: \`${{ steps.ecr.outputs.registry }}/${{ env.ECR_REPO }}:${{ github.sha }}\`"
+            echo "Task definition: \`${{ steps.register.outputs.td_arn }}\`"
+            echo "Cluster/Service: \`${{ env.CLUSTER }} / ${{ env.SERVICE }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/DEPLOY-WINDOWS.md
+++ b/DEPLOY-WINDOWS.md
@@ -1,6 +1,6 @@
 # End-to-end deployment runbook (Windows)
 
-Stand up the infra, install Spinnaker, then get the **push-to-main → auto-deploy**
+Stand up the infra, then get the **push-to-main → auto-deploy**
 loop working. Every command is PowerShell. Run them from a regular PowerShell
 window (not cmd). Copy blocks one at a time and read the comments.
 
@@ -8,21 +8,35 @@ window (not cmd). Copy blocks one at a time and read the comments.
 git push origin main
    │
    ▼
-GitHub Actions   build + test, Jib pushes image to ECR (auth via OIDC, no keys)
-   │  POST webhook
+GitHub Actions
+   • test + Jib build + push image to ECR
+   • aws ecs register-task-definition  (new revision)
+   • aws ecs update-service (or create-service on first run)
+   • aws ecs wait services-stable
+   │
    ▼
-Spinnaker (on EKS)   createServerGroup (red/black)
-   ▼
-ECS Fargate   new task revision goes live behind the ALB
+ECS Fargate   rolling deploy, ALB starts routing traffic to the new tasks
 ```
 
-**Ownership:** Terraform owns the immutable platform (EKS for Spinnaker, plus
-the EMS ALB / ECS cluster / RDS / ECR / IAM / secrets). Spinnaker owns the ECS
-**services and task definitions** — it creates them on the first pipeline run.
+**Ownership:** Terraform owns the immutable platform (ALB, ECS cluster, RDS,
+ECR, IAM, secrets). GitHub Actions owns the ECS **service + task definitions**
+— created on the first push, updated on every subsequent push. Idempotent.
 
-> **Cost warning.** This runs an EKS cluster (2× t3.large), an RDS instance, an
-> ALB, and 2 network load balancers. Ballpark **$10–15/day** left running. Tear
-> down with the Phase 9 steps when you're done for the day.
+> **About Spinnaker:** Phases 2–3 install a real Spinnaker on EKS for learning,
+> but it is NOT in the deploy path. Spinnaker-on-ECS has long-standing caching
+> bugs (`EcsSecurityGroupCachingAgent` never populates → `SecurityGroupSelector`
+> NPEs) that bite anyone who tries to use `createServerGroup` for Fargate.
+> Most production teams use `aws ecs` directly for Fargate and reserve
+> Spinnaker for Kubernetes — that's the pattern this repo follows.
+>
+> **If you don't care about learning Spinnaker, skip Phases 2 and 3** —
+> deploy.yml needs only Phase 1, 4, 6, 7 to work. Phase 2's `terraform
+> apply` is still needed because it creates the GitHub OIDC role (but you
+> can drop everything else in `terraform/spinnaker` if you want a truly
+> minimal setup later).
+
+> **Cost warning.** Full setup runs an EKS cluster (2× t3.large), RDS, an ALB,
+> and 2 NLBs. Ballpark **$10–15/day** left running. Phase 9 tears it down.
 
 ---
 
@@ -321,7 +335,12 @@ without the other.
 
 ---
 
-## Phase 5 — Configure Spinnaker (one time)
+## Phase 5 — Configure Spinnaker (OPTIONAL — for learning/visibility only)
+
+> Spinnaker is **not** the deployer (see "About Spinnaker" at the top).
+> Skip this whole phase if you just want a working push-to-deploy. The app
+> deploys via `aws ecs` in Phase 7 regardless. Phase 5 only sets up Spinnaker
+> to **observe** deploys via the optional Slack-style notification webhook.
 
 In the Deck UI (the URL from 3e):
 
@@ -382,88 +401,53 @@ add those environments and a Jenkins for BlazeMeter.
 
 ## Phase 6 — Wire GitHub Actions (the auto-deploy trigger)
 
-The workflow `.github/workflows/deploy.yml` is already in the repo. Three setup
-steps: get the values, save them to GitHub, open the network so GitHub can reach
-Spinnaker.
+The workflow `.github/workflows/deploy.yml` is already in the repo. Two setup
+steps: get the role ARN, save it on GitHub.
 
-### 6a. Gather the exact values to paste
+### 6a. Gather the values
 
-In PowerShell, from `terraform\spinnaker`:
+In PowerShell, from `terraform\spinnaker` (the OIDC role is owned by that root):
 
 ```powershell
 cd E:\projects\practice\terraform\spinnaker
-
-# the ARN for the app deploy role (NOT the infra one, NOT the spinnaker one)
 $ROLE_ARN = (terraform output -raw github_actions_role_arn)
 
-# the Gate hostname (from 3e — re-grab if blank)
-$GATE = kubectl -n spinnaker get svc spin-gate -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
-
-# any random string — not enforced right now
-$WEBHOOK_TOKEN = [guid]::NewGuid().ToString()
-
-# print the four values to paste
-"AWS_ROLE_ARN              = $ROLE_ARN"
-"AWS_REGION                = us-east-1"
-"SPINNAKER_GATE_URL        = http://$GATE"
-"SPINNAKER_WEBHOOK_TOKEN   = $WEBHOOK_TOKEN"
+"AWS_ROLE_ARN  = $ROLE_ARN"
+"AWS_REGION    = us-east-1"
 ```
 
 > **Which ARN is "the" ARN?** You may see several roles in the spinnaker outputs.
-> The one for GitHub Actions building+pushing images is
-> **`github_actions_role_arn`** (no `_infra`). The others are for the infra
-> workflow, Spinnaker itself, or ECS tasks — don't paste those here.
+> The one for GitHub Actions building + deploying is **`github_actions_role_arn`**
+> (no `_infra`). The others are for the infra workflow, Spinnaker itself, or
+> ECS tasks — don't paste those here.
 
 ### 6b. Save them on GitHub
 
-GitHub → repo → **Settings → Secrets and variables → Actions**.
+GitHub → repo → **Settings → Secrets and variables → Actions → Variables tab → New repository variable**:
 
-**Variables tab → New repository variable** (×3):
+| Name           | Value           |
+|----------------|-----------------|
+| `AWS_ROLE_ARN` | `$ROLE_ARN`     |
+| `AWS_REGION`   | `us-east-1`     |
 
-| Name                | Value (from 6a)         |
-|---------------------|-------------------------|
-| `AWS_ROLE_ARN`      | `$ROLE_ARN`             |
-| `AWS_REGION`        | `us-east-1`             |
-| `SPINNAKER_GATE_URL`| `http://$GATE` (no port, no trailing slash — see 3e port warning) |
+That's it for the required config. The workflow handles everything else.
 
-**Secrets tab → New repository secret** (×1):
+### 6c. Optional — Spinnaker notification
 
-| Name                      | Value                  |
-|---------------------------|------------------------|
-| `SPINNAKER_WEBHOOK_TOKEN` | `$WEBHOOK_TOKEN`       |
+If you also did Phase 3 + 5 (Spinnaker for visibility), add these so the
+workflow posts a deploy event to Spinnaker. Workflow continues without them.
 
-### 6c. Open the network so GitHub can reach Spinnaker Gate
-
-The Gate NLB needs to accept inbound HTTP from GitHub's runners on **port 80**
-(the external port — see 3e). Two paths depending on what AWS shows you:
-
-**If the Gate NLB has a security group in its console page**, edit that SG and
-add: Type `Custom TCP`, Port `80`, Source `0.0.0.0/0`. Done.
-
-**If the Gate NLB shows "No security group associated"** (common — older-style
-NLB), traffic is gated at the **EKS worker nodes** instead. Open *their* SG:
-
+In `terraform\spinnaker`:
 ```powershell
-# get any one EKS worker node name
-kubectl get nodes -o jsonpath='{.items[0].metadata.name}'
+$GATE = kubectl -n spinnaker get svc spin-gate -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+$WEBHOOK_TOKEN = [guid]::NewGuid().ToString()
+"SPINNAKER_GATE_URL      = http://$GATE"
+"SPINNAKER_WEBHOOK_TOKEN = $WEBHOOK_TOKEN"
 ```
 
-Then in AWS Console:
-1. **EC2 → Instances** → search/paste that node name → click the instance.
-2. **Security** tab → click the security group link (named like
-   `eks-cluster-sg-spinnaker-...`).
-3. **Inbound rules → Edit inbound rules → Add rule:**
-   - Type: **Custom TCP**
-   - Port: **80**
-   - Source: **0.0.0.0/0**
-4. **Save rules.**
-
-> **Safer (later):** Source `0.0.0.0/0` lets the whole internet hit your Gate.
-> Fine for a learning run while NLB auth is off. To scope it down, replace the
-> source with GitHub's published runner IP ranges from
-> `https://api.github.com/meta` (the `actions` array). Or skip this step
-> entirely and trigger the pipeline manually from the Deck UI — no inbound
-> rule needed.
+Add `SPINNAKER_GATE_URL` as a Variable and `SPINNAKER_WEBHOOK_TOKEN` as a
+Secret. Plus open the Gate NLB (EKS worker nodes' SG) for inbound TCP 80 —
+see the original Phase 6c steps in git history if you want it locked down.
 
 ---
 
@@ -472,38 +456,72 @@ Then in AWS Console:
 From your laptop:
 
 ```powershell
-cd practice
-# make a change, e.g. edit README, then:
+cd E:\projects\practice
+# make any change, then:
 git add .
 git commit -m "test: trigger first auto-deploy"
 git push origin main
 ```
 
-Watch the loop:
+What happens (idempotent — same flow on first push and every push after):
 
-1. **GitHub → Actions tab** — the `deploy` workflow runs: test → Jib build/push
-   → "Trigger Spinnaker pipeline". ~3–6 min.
-2. **Spinnaker UI → ems → Pipelines** — an execution starts. With the
-   dev-only pipeline imported, it runs just **Deploy to Dev** and stops there.
-   (Pre-merge of perf/prod work, you'd swap to `ems-deploy-cicd.json`.)
-3. **AWS Console → ECS → `ems-dev` cluster** — a new service/task revision
-   appears and reaches `RUNNING`.
-4. **Verify it's live:**
+1. **GitHub → Actions tab** — the `deploy` workflow runs:
+   - test → Jib build → push image to ECR as `ems:<commit-sha>`
+   - look up VPC / subnets / SG / target group ARN / account
+   - render `ecs/taskdef.dev.json.tpl` with the new image
+   - `aws ecs register-task-definition` → new revision
+   - `aws ecs create-service` (first push) **or** `aws ecs update-service --force-new-deployment` (later pushes)
+   - `aws ecs wait services-stable` → blocks until rollout is healthy
+   - ~5–8 min total.
+2. **AWS Console → ECS → `ems-dev` cluster** — service shows the new task definition, tasks rolling.
+3. **Verify it's live:**
    ```powershell
+   cd E:\projects\practice\terraform\ems
+   $ALB = (terraform output -raw alb_url)
    curl "$ALB/actuator/health"      # -> {"status":"UP"}
    ```
 
-That's the full CI/CD loop. Every subsequent `git push origin main` repeats
-steps 1–4 automatically.
+> Every subsequent `git push origin main` repeats steps 1–3 automatically.
+
+### Where the deploy logic lives
+
+- **`ecs/taskdef.dev.json.tpl`** — task definition template. `__ACCOUNT__` and
+  `__IMAGE__` placeholders get substituted by the workflow.
+- **`.github/workflows/deploy.yml`** — the workflow. Builds the image, renders
+  the task def, registers it, updates the service.
+- **`terraform/spinnaker/github_oidc.tf`** — grants the GitHub Actions role
+  the AWS permissions needed (ECR push, EC2/ELB describe, ECS register/update
+  scoped to `ems-*`, IAM PassRole scoped to `ems-*-task*`).
+
+### If you ever need to redo this from scratch
+
+1. Phase 1 (S3 + DynamoDB) — one-time.
+2. Phase 2 (`terraform/spinnaker` apply) — creates the GitHub OIDC role with all
+   the ECR + ECS + IAM PassRole perms needed.
+3. Phase 3–5 — skip if you don't want Spinnaker.
+4. Phase 4 (`terraform/ems` apply) — creates the ALB, ECS cluster (empty), RDS,
+   ECR, IAM roles, secrets, log group.
+5. Phase 6 — set `AWS_ROLE_ARN` and `AWS_REGION` GitHub Variables.
+6. `git push origin main` — first push creates the ECS service.
 
 ---
 
 ## Phase 8 — Rollback
 
-In the Spinnaker UI → **ems → Clusters**, select the previous server group →
-**Enable**, then disable the bad one. Red/black keeps the prior version around
-(`maxRemainingAsgs=2`) specifically for this one-click rollback. Nothing to
-script.
+ECS keeps every task definition revision, so rollback is one CLI call:
+
+```powershell
+# list recent revisions
+aws ecs list-task-definitions --family-prefix ems-dev --sort DESC --max-items 5
+
+# roll the service back to a previous revision (paste a known-good ARN)
+aws ecs update-service --cluster ems-dev --service ems-dev `
+  --task-definition arn:aws:ecs:us-east-1:<account>:task-definition/ems-dev:<n> `
+  --force-new-deployment
+```
+
+ECS does a rolling deploy back to that revision (maxPercent=200/minHealthy=100,
+configured in `deploy.yml`). No data loss, ~2–3 min.
 
 ---
 

--- a/ecs/taskdef.dev.json.tpl
+++ b/ecs/taskdef.dev.json.tpl
@@ -1,0 +1,37 @@
+{
+  "family": "ems-dev",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "512",
+  "memory": "1024",
+  "executionRoleArn": "arn:aws:iam::__ACCOUNT__:role/ems-dev-task-exec",
+  "taskRoleArn": "arn:aws:iam::__ACCOUNT__:role/ems-dev-task",
+  "containerDefinitions": [
+    {
+      "name": "ems",
+      "image": "__IMAGE__",
+      "essential": true,
+      "portMappings": [
+        { "containerPort": 8080, "protocol": "tcp" }
+      ],
+      "environment": [
+        { "name": "SPRING_PROFILES_ACTIVE", "value": "dev" }
+      ],
+      "secrets": [
+        { "name": "DB_HOST",     "valueFrom": "arn:aws:ssm:us-east-1:__ACCOUNT__:parameter/dev/ems/DB_HOST" },
+        { "name": "DB_PORT",     "valueFrom": "arn:aws:ssm:us-east-1:__ACCOUNT__:parameter/dev/ems/DB_PORT" },
+        { "name": "DB_NAME",     "valueFrom": "arn:aws:ssm:us-east-1:__ACCOUNT__:parameter/dev/ems/DB_NAME" },
+        { "name": "DB_USERNAME", "valueFrom": "arn:aws:ssm:us-east-1:__ACCOUNT__:parameter/dev/ems/DB_USERNAME" },
+        { "name": "DB_PASSWORD", "valueFrom": "arn:aws:secretsmanager:us-east-1:__ACCOUNT__:secret:/dev/ems/DB_PASSWORD" }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group":         "/ecs/ems-dev",
+          "awslogs-region":        "us-east-1",
+          "awslogs-stream-prefix": "ecs"
+        }
+      }
+    }
+  ]
+}

--- a/terraform/spinnaker/github_oidc.tf
+++ b/terraform/spinnaker/github_oidc.tf
@@ -85,17 +85,59 @@ data "aws_iam_policy_document" "github_actions" {
     resources = ["arn:aws:ecr:${var.aws_region}:${var.aws_account_id}:repository/ems"]
   }
 
-  # Read-only lookup of the Fargate networking IDs at deploy time so the
-  # Spinnaker pipeline doesn't need them hardcoded. Used by the "Resolve
-  # subnet + security group IDs" step in deploy.yml.
+  # Read-only inventory for deploy.yml's lookup step (VPC, subnets, SG,
+  # target group). Account-scoped read; these APIs require resources: "*".
   statement {
     sid = "DescribeNetworkingForDeploy"
     actions = [
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeSubnets",
       "ec2:DescribeVpcs",
+      "elasticloadbalancing:DescribeTargetGroups",
     ]
     resources = ["*"]
+  }
+
+  # ECS deploy: register a new task definition revision and create/update the
+  # ems-dev service. Task def registration must be account-wide (the API takes
+  # resources: "*"); service mutations are scoped to the ems-dev service ARN.
+  statement {
+    sid = "EcsRegisterTaskDef"
+    actions = [
+      "ecs:RegisterTaskDefinition",
+      "ecs:DescribeTaskDefinition",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "EcsServiceDeploy"
+    actions = [
+      "ecs:CreateService",
+      "ecs:UpdateService",
+      "ecs:DescribeServices",
+      "ecs:ListServices",
+      "ecs:DescribeClusters",
+    ]
+    resources = [
+      "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:cluster/ems-*",
+      "arn:aws:ecs:${var.aws_region}:${var.aws_account_id}:service/ems-*/ems-*",
+    ]
+  }
+
+  # ECS needs to pass the task-exec and task roles into the running container.
+  statement {
+    sid = "PassEcsTaskRoles"
+    actions = ["iam:PassRole"]
+    resources = [
+      "arn:aws:iam::${var.aws_account_id}:role/ems-*-task",
+      "arn:aws:iam::${var.aws_account_id}:role/ems-*-task-exec",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
   }
 }
 


### PR DESCRIPTION
After hitting Spinnaker-on-ECS's well-known caching bug (`EcsSecurityGroupCachingAgent` doesn't populate → `SecurityGroupSelector` NPEs even with explicit IDs), this PR switches the deploy path to `aws ecs` directly — the pattern most production teams use for Fargate.

End-to-end repeatable: works on the **first push** (creates the service) and **every push after** (updates it). No manual UI clicks, no clouddriver subnet-type registration, no Spinnaker pipeline JSON. Spinnaker stays installed for learning; it just isn't in the deploy path.

## What's new
- **`ecs/taskdef.dev.json.tpl`** — task definition template with `__ACCOUNT__` / `__IMAGE__` placeholders. SSM / Secrets Manager ARNs match what `terraform/ems/secrets.tf` creates.
- **`.github/workflows/deploy.yml`** — rewritten. After Jib build:
  - Look up VPC, subnets (excluding `us-east-1e`), SG `ems-dev-tasks`, target group `ems-dev-stable`.
  - Render the task def, `ecs register-task-definition`.
  - **Idempotent service create-or-update**: `describe-services` → if `ACTIVE`, `update-service --force-new-deployment`; else `create-service` with networking + ALB + health check grace + deployment config.
  - `aws ecs wait services-stable`.
  - Spinnaker notification stays as an **optional, best-effort** step (`continue-on-error: true`, only runs if `SPINNAKER_GATE_URL` is set).
- **`terraform/spinnaker/github_oidc.tf`** — adds the deploy perms:
  - `ecs:RegisterTaskDefinition` / `DescribeTaskDefinition` (account-wide).
  - `ecs:CreateService` / `UpdateService` / `DescribeServices` / `ListServices` / `DescribeClusters` scoped to `ems-*`.
  - `iam:PassRole` scoped to `ems-*-task*` with `iam:PassedToService=ecs-tasks.amazonaws.com`.
  - `elasticloadbalancing:DescribeTargetGroups`.

## Runbook (`DEPLOY-WINDOWS.md`)
- Banner at the top explains Spinnaker is no longer in the deploy path and why.
- Phase 5 marked **optional** (Spinnaker for learning / visibility only).
- Phase 6 reduced to `AWS_ROLE_ARN` + `AWS_REGION`; Spinnaker vars moved to `6c` as optional.
- Phase 7 rewritten to reflect the actual flow + a "redo from scratch" checklist.
- Phase 8 rollback now an `aws ecs update-service` to a previous taskdef revision (replaces the Spinnaker red/black UI rollback).

## After merge
```powershell
git pull origin main
cd terraform\spinnaker
·t·erraform a·pply          # picks up new ECS deploy perms
cd ..\..
git commit --allow-empty -m "first ECS deploy"
git push origin main
```

First push creates the ECS service; subsequent pushes update it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014F6umrv1Uoj7W5GxkK84K4)_