### PR TITLE
Drop Spinnaker notify from deploy workflow (stops the failing pipeline)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,21 +171,6 @@ jobs:
             --services "${SERVICE}"
           echo "Deployment stable."
 
-      # -----------------------------------------------------------------------
-      # Optional: notify Spinnaker so the UI shows a deploy event. Best-effort
-      # only — a Spinnaker outage must not fail the deploy. Skipped entirely
-      # if SPINNAKER_GATE_URL is unset.
-      # -----------------------------------------------------------------------
-      - name: Notify Spinnaker (optional, best-effort)
-        if: ${{ vars.SPINNAKER_GATE_URL != '' }}
-        continue-on-error: true
-        run: |
-          curl -fsS -X POST "${{ vars.SPINNAKER_GATE_URL }}/webhooks/webhook/ems-build-complete" \
-            -H "X-Spinnaker-Token: ${{ secrets.SPINNAKER_WEBHOOK_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{\"parameters\":{\"imageTag\":\"${{ github.sha }}\",\"branch\":\"main\",\"ecrRegistry\":\"${{ steps.ecr.outputs.registry }}\",\"ecrRepo\":\"${{ env.ECR_REPO }}\",\"buildUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}}" \
-            || echo "Spinnaker notify failed (non-fatal)."
-
       - name: Summary
         run: |
           {

--- a/spinnaker/README.md
+++ b/spinnaker/README.md
@@ -1,4 +1,15 @@
-# Spinnaker pipeline (ECS Fargate)
+# Spinnaker pipeline (ECS Fargate) — REFERENCE ONLY, NOT THE DEPLOYER
+
+> **These pipelines are not used for deploys.** Spinnaker's ECS integration
+> has long-standing caching bugs (`EcsSecurityGroupCachingAgent` never
+> populates → `createServerGroup` NPEs in `SecurityGroupSelector`, even with
+> explicit subnet/SG IDs). The actual deploy path is **`aws ecs` directly from
+> `.github/workflows/deploy.yml`** — see `DEPLOY-WINDOWS.md` Phase 7.
+>
+> These JSON files are kept as a reference for the red/black + canary pipeline
+> *shape* (useful if you ever deploy to Kubernetes via Spinnaker, where it
+> works well). Importing them and wiring the GitHub webhook will produce
+> failing executions — don't.
 
 Pipeline definition for the EMS app. Imports into an existing Spinnaker
 install — provisioning Spinnaker itself is in `terraform/spinnaker/`.


### PR DESCRIPTION
The direct-ECS deploy works (app is live, `/actuator/health` returns 200). But the optional "Notify Spinnaker" step in the workflow POSTed to the webhook, which re-triggered the broken `ems-deploy-dev-only` Spinnaker pipeline and produced a failing execution on every otherwise-successful deploy. Spinnaker isn't in the deploy path, so the workflow shouldn't touch it.

- **`deploy.yml`**: remove the "Notify Spinnaker" step entirely. The workflow now does exactly one thing — build + deploy to ECS.
- **`spinnaker/README.md`**: banner marking the pipeline JSONs as reference-only (Spinnaker-on-ECS doesn't work; importing + wiring the webhook produces failing executions).

After merge, the user can also delete the `SPINNAKER_GATE_URL` GitHub variable and the `ems-deploy-dev-only` pipeline in Deck to fully silence the noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014F6umrv1Uoj7W5GxkK84K4)_