### PR TITLE
Spinnaker ECS fix: tag subnets with immutable_metadata so subnetType resolves

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -171,6 +171,24 @@ jobs:
             --services "${SERVICE}"
           echo "Deployment stable."
 
+      # -----------------------------------------------------------------------
+      # OPTIONAL: trigger Spinnaker's parallel ECS deploy for learning.
+      # Only runs when the SPINNAKER_GATE_URL variable is set in the repo.
+      # Spinnaker deploys to a separate stack (`ems-spinnaker-vNNN`) on the
+      # canary target group, so it can NEVER disturb the live `ems-dev`
+      # service deployed above. continue-on-error means a Spinnaker failure
+      # won't fail this workflow.
+      # -----------------------------------------------------------------------
+      - name: Trigger Spinnaker (optional learning path)
+        if: ${{ vars.SPINNAKER_GATE_URL != '' }}
+        continue-on-error: true
+        run: |
+          curl -fsS -X POST "${{ vars.SPINNAKER_GATE_URL }}/webhooks/webhook/ems-build-complete" \
+            -H "X-Spinnaker-Token: ${{ secrets.SPINNAKER_WEBHOOK_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"parameters\":{\"imageTag\":\"${{ github.sha }}\",\"branch\":\"main\",\"ecrRegistry\":\"${{ steps.ecr.outputs.registry }}\",\"ecrRepo\":\"${{ env.ECR_REPO }}\",\"buildUrl\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}}" \
+            || echo "Spinnaker notify failed (non-fatal)."
+
       - name: Summary
         run: |
           {

--- a/spinnaker/pipelines/ems-deploy-dev-only.json
+++ b/spinnaker/pipelines/ems-deploy-dev-only.json
@@ -32,9 +32,7 @@
     { "name": "appId",          "required": false, "default": "APP-EMS-UNASSIGNED" },
     { "name": "buildUrl",       "required": false, "description": "Link back to the GitHub Actions run" },
     { "name": "ecrRegistry",    "required": true,  "description": "<account>.dkr.ecr.<region>.amazonaws.com" },
-    { "name": "ecrRepo",        "required": false, "default": "ems" },
-    { "name": "subnetIds",      "required": true,  "description": "Comma-separated subnet IDs for the Fargate tasks. Resolved by GitHub Actions from AWS so no clouddriver subnet-type registration is needed." },
-    { "name": "securityGroupId","required": true,  "description": "Security group ID (sg-...) for the Fargate tasks. Resolved by GitHub Actions." }
+    { "name": "ecrRepo",        "required": false, "default": "ems" }
   ],
 
   "triggers": [
@@ -55,7 +53,7 @@
       "credentials": "aws-dev",
       "region": "us-east-1",
       "application": "ems",
-      "stack": "dev",
+      "stack": "spinnaker",
       "ecsClusterName": "ems-dev",
       "launchType": "FARGATE",
       "platformVersion": "LATEST",
@@ -79,12 +77,12 @@
         {
           "containerName": "ems",
           "containerPort": 8080,
-          "targetGroup":   "ems-dev-stable"
+          "targetGroup":   "ems-dev-canary"
         }
       ],
       "networkMode": "awsvpc",
-      "subnetType":  "${parameters.subnetIds}",
-      "securityGroups": ["${parameters.securityGroupId}"],
+      "subnetType":  "ecs-tasks-dev",
+      "securityGroups": ["ems-dev-tasks"],
       "associatePublicIpAddress": true,
       "iamRole":              "ems-dev-task-exec",
       "taskRoleArn":          "ems-dev-task",

--- a/terraform/ems/spinnaker_subnet_tags.tf
+++ b/terraform/ems/spinnaker_subnet_tags.tf
@@ -1,0 +1,30 @@
+# ---------------------------------------------------------------------------
+# Spinnaker subnet tagging.
+#
+# Spinnaker's ECS/AWS clouddriver resolves `subnetType` by reading a tag
+# called `immutable_metadata` (Netflix convention) and parsing its JSON value
+# for a `purpose` field that must equal the `subnetType` string in the
+# pipeline. Without these tags the resolver returns null, the VPC can't be
+# derived, the security-group cache is keyed by a null VPC, and
+# `SecurityGroupSelector` NPEs with "Cannot invoke Collection.size()".
+#
+# We tag each default-VPC subnet (already filtered to EKS-supported AZs in
+# data.tf) so Spinnaker's pipeline can use `subnetType: "ecs-tasks-dev"` and
+# `securityGroups: ["ems-dev-tasks"]` as Spinnaker intends, without the
+# GitHub-Actions-side ID lookup workaround.
+#
+# These tags are added BY terraform but live ON resources terraform doesn't
+# own (default VPC subnets). aws_ec2_tag is the right tool — it adds/removes
+# only the named tag and never touches anything else on the subnet.
+# ---------------------------------------------------------------------------
+
+resource "aws_ec2_tag" "spinnaker_subnet_purpose" {
+  for_each = toset(data.aws_subnets.default.ids)
+
+  resource_id = each.value
+  key         = "immutable_metadata"
+  value       = jsonencode({
+    purpose = "ecs-tasks-${var.env}"
+    target  = "ec2"
+  })
+}


### PR DESCRIPTION
Real root-cause fix for the long-running Spinnaker-on-ECS `Collection.size()` NPE.

## Root cause

Spinnaker's clouddriver resolves `subnetType` (`"ecs-tasks-dev"`) by scanning subnets for an `immutable_metadata` tag whose JSON value has a `purpose` field equal to that string. Default-VPC subnets don't have it, so:

1. `resolveSubnets()` returns `null`.
2. The VPC for the SG cache lookup is `null`.
3. `SecurityGroupSelector.resolveSecurityGroupNames()` does `new HashSet<>(c)` where `c` is null → NPE.

Our earlier ID-passing workaround didn't help because clouddriver still went through the same name resolution path. Tagging the subnets is the actual fix.

## Changes

- **`terraform/ems/spinnaker_subnet_tags.tf`** (new): `aws_ec2_tag` adds `immutable_metadata = {"purpose":"ecs-tasks-<env>","target":"ec2"}` to every default-VPC subnet in `data.aws_subnets.default` (already filtered to EKS-supported AZs).
- **`spinnaker/pipelines/ems-deploy-dev-only.json`**:
  - Revert to name-based lookups: `subnetType: "ecs-tasks-dev"`, `securityGroups: ["ems-dev-tasks"]` — what Spinnaker's resolvers were designed for, now that the tag exists.
  - Drop the `subnetIds` / `securityGroupId` parameters (no longer needed).
  - `stack: "dev"` → `stack: "spinnaker"` so Spinnaker's server group is `ems-spinnaker-vNNN` and can't collide with the directly-deployed `ems-dev` service.
  - Target group → `ems-dev-canary` so Spinnaker's tasks are isolated from live traffic on `ems-dev-stable`.
- **`.github/workflows/deploy.yml`**: re-add an OPTIONAL Spinnaker notify step gated on `vars.SPINNAKER_GATE_URL` with `continue-on-error: true`. Direct-ECS deploy stays primary; Spinnaker runs in parallel for learning and can never fail the workflow.

## After merge

```powershell
git pull origin main
cd terraform\ems
·t·erraform a·pply               # tags the subnets
cd ..\..
spin pipeline save --file spinnaker\pipelines\ems-deploy-dev-only.json
# wait ~60s for clouddriver caches to pick up the new tags
git commit --allow-empty -m "test spinnaker after subnet tags"
git push origin main
```

The direct-ECS deploy will go green as before. The Spinnaker pipeline will fire in parallel — if the tag fix works, it'll create `ems-spinnaker-v000` on the canary target group. If it fails, the workflow still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014F6umrv1Uoj7W5GxkK84K4)_