### PR TITLE
Promote clouddriver cache refresh into setup instructions

### DIFF
--- a/docs/app-deploy/INSTRUCTIONS.md
+++ b/docs/app-deploy/INSTRUCTIONS.md
@@ -157,6 +157,20 @@ Then re-import the Spinnaker pipeline:
 spin pipeline save --file E:\projects\practice\spinnaker\pipelines\ems-deploy-dev-only.json
 ```
 
+Refresh clouddriver's cache so it picks up the subnet `immutable_metadata`
+tag added by `terraform/ems` (skip only if you're certain clouddriver
+started **after** that terraform apply):
+
+```powershell
+kubectl -n spinnaker rollout restart deploy/spin-clouddriver
+kubectl -n spinnaker rollout status deploy/spin-clouddriver
+Start-Sleep -Seconds 120
+```
+
+Without this the first Spinnaker run NPEs in Monitor Deploy with
+`Cannot invoke "java.util.Collection.size()" because "c" is null`. ECS
+itself still deploys fine — only the Spinnaker stage fails.
+
 Next `git push origin main`:
 - GitHub Actions deploys to `ems-dev` (the real deploy).
 - Spinnaker runs in parallel, creates `ems-spinnaker-vNNN` on the canary

--- a/docs/spinnaker-infra/INSTRUCTIONS.md
+++ b/docs/spinnaker-infra/INSTRUCTIONS.md
@@ -263,6 +263,27 @@ spin pipeline save --file spinnaker\pipelines\ems-deploy-dev-only.json
 
 In Deck: **ems → Pipelines** → you should see `ems-deploy-dev-only`.
 
+### 4d — Refresh clouddriver's cache before the first trigger
+
+`spin-clouddriver` caches AWS inventory on startup. If Spinnaker started
+**before** `terraform/ems` added the subnet `immutable_metadata` tag — or
+you destroyed and re-applied terraform — the cache is missing the
+`subnetType → vpcId` mapping. The first pipeline run will then NPE in the
+Monitor Deploy stage with `Cannot invoke "java.util.Collection.size()"
+because "c" is null`.
+
+Force a re-cache once, right after Phase 4c:
+
+```powershell
+kubectl -n spinnaker rollout restart deploy/spin-clouddriver
+kubectl -n spinnaker rollout status deploy/spin-clouddriver
+Start-Sleep -Seconds 120   # let the caching agents complete one full cycle
+```
+
+You only need to do this when the subnet tags appeared after clouddriver
+last started — i.e., the first time on a fresh stack, and after any
+`terraform destroy` + re-apply.
+
 ---
 
 ## Tearing it all down (end of day)
@@ -291,7 +312,7 @@ terraform destroy        # type yes
 3. Phase 3a–c — kubectl operator + SpinnakerService.
 4. Phase 3d — wait for pods.
 5. Phase 3e — grab URLs.
-6. *(Optional Phase 4)* — Spinnaker app + pipeline.
+6. *(Optional Phase 4)* — Spinnaker app + pipeline + clouddriver cache refresh (4d).
 
 That's it. The 9 PRs of fixes are all in `main`, so a fresh clone should
 go end-to-end without the snags we hit live.


### PR DESCRIPTION
The "Cannot invoke Collection.size() because c is null" NPE was buried in DEBUG.md, so it kept being a first-run surprise. Add an explicit Phase 4d to spinnaker-infra/INSTRUCTIONS.md and a parallel step in app-deploy Phase 5 telling users to rollout-restart spin-clouddriver and wait for one cache cycle whenever subnet tags appeared after clouddriver started (fresh install, terraform destroy + re-apply).